### PR TITLE
make tray icon to a bigger font size

### DIFF
--- a/src/main/core/mihomoApi.ts
+++ b/src/main/core/mihomoApi.ts
@@ -193,8 +193,8 @@ const mihomoTraffic = async (): Promise<void> => {
       const svgContent = `
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 125 36">
         <image height='36' width='36' href='data:image/png;base64,${base64}'/>
-        <text x='40' y='15' font-size='15' font-family='system-ui'>↑ ${calcTraffic(json.up)}/s</text>
-        <text x='40' y='32' font-size='15' font-family='system-ui'>↓ ${calcTraffic(json.down)}/s</text>
+        <text x='40' y='15' font-size='18' font-family='system-ui'>↑ ${calcTraffic(json.up)}</text>
+        <text x='40' y='36' font-size='18' font-family='system-ui'>↓ ${calcTraffic(json.down)}</text>
       </svg>`
       svg2img(svgContent, {}, (error, buffer) => {
         if (error) return


### PR DESCRIPTION
状态栏字体大小偏小，无法看清，所以将字体调整到18号，并将网速单位由去掉/s（KB/s→KB，应该不会产生歧义的），现在效果还不错，如图：
<img width="273" alt="image" src="https://github.com/user-attachments/assets/612ab977-10c1-4533-b88a-edf7c8493078">
