### PR TITLE
fix AUR Build

### DIFF
--- a/aur/mihomo-party-bin/PKGBUILD
+++ b/aur/mihomo-party-bin/PKGBUILD
@@ -23,9 +23,8 @@ package() {
     chmod +x ${pkgdir}/opt/mihomo-party/mihomo-party
     chmod +x ${pkgdir}/opt/mihomo-party/resources/sidecar/mihomo
     chmod +x ${pkgdir}/opt/mihomo-party/resources/sidecar/mihomo-alpha
-    cd ${pkgdir}/../..
-	install -Dm755 "${_pkgname}.sh" "${pkgdir}/usr/bin/${_pkgname}"
-	sed -i '3s!/opt/mihomo-party/mihomo-party!mihomo-party!' "${pkgdir}/usr/share/applications/${_pkgname}.desktop"
+    install -Dm755 "${srcdir}/${pkgname}.sh" "${pkgdir}/usr/bin/${pkgname}"
+    sed -i '3s!/opt/mihomo-party/mihomo-party!mihomo-party!' "${pkgdir}/usr/share/applications/${_pkgname}.desktop"
 
     chown -R root:root ${pkgdir}
 }

--- a/aur/mihomo-party-electron-bin/PKGBUILD
+++ b/aur/mihomo-party-electron-bin/PKGBUILD
@@ -29,8 +29,7 @@ package() {
     cp -r $srcdir/opt/mihomo-party/resources/files ${pkgdir}/opt/mihomo-party/resources/
     chmod +x ${pkgdir}/opt/mihomo-party/resources/sidecar/mihomo
     chmod +x ${pkgdir}/opt/mihomo-party/resources/sidecar/mihomo-alpha
-    cd ${pkgdir}/../..
-	install -Dm755 "${_pkgname}.sh" "${pkgdir}/usr/bin/${_pkgname}"
+    install -Dm755 "${srcdir}/${pkgname}.sh" "${pkgdir}/usr/bin/${pkgname}"
     install -Dm644 "${_pkgname}.desktop" "${pkgdir}/usr/share/applications/${_pkgname}.desktop"
     install -Dm644 "${pkgdir}/opt/mihomo-party/resources/icon.png" "${pkgdir}/usr/share/icons/hicolor/512x512/apps/${_pkgname}.png"
 

--- a/aur/mihomo-party-electron/PKGBUILD
+++ b/aur/mihomo-party-electron/PKGBUILD
@@ -38,8 +38,7 @@ package() {
     cp -r $srcdir/${_pkgname}-${pkgver}/extra/files ${pkgdir}/opt/mihomo-party/resources/
     chmod +x ${pkgdir}/opt/mihomo-party/resources/sidecar/mihomo
     chmod +x ${pkgdir}/opt/mihomo-party/resources/sidecar/mihomo-alpha
-    cd ${pkgdir}/../..
-	install -Dm755 "${_pkgname}.sh" "${pkgdir}/usr/bin/${_pkgname}"
+    install -Dm755 "${srcdir}/${pkgname}.sh" "${pkgdir}/usr/bin/${pkgname}"
     install -Dm644 "${_pkgname}.desktop" "${pkgdir}/usr/share/applications/${_pkgname}.desktop"
     install -Dm644 "${pkgdir}/opt/mihomo-party/resources/icon.png" "${pkgdir}/usr/share/icons/hicolor/512x512/apps/${_pkgname}.png"
 

--- a/aur/mihomo-party-git/PKGBUILD
+++ b/aur/mihomo-party-git/PKGBUILD
@@ -40,10 +40,8 @@ package() {
     chmod +x ${pkgdir}/opt/mihomo-party/mihomo-party
     chmod +x ${pkgdir}/opt/mihomo-party/resources/sidecar/mihomo
     chmod +x ${pkgdir}/opt/mihomo-party/resources/sidecar/mihomo-alpha
-    cd ${pkgdir}/../..
-	install -Dm755 "${_pkgname}.sh" "${pkgdir}/usr/bin/${_pkgname}"
-
-	sed -i '3s!/opt/mihomo-party/mihomo-party!mihomo-party!' "${pkgdir}/usr/share/applications/${_pkgname}.desktop"
+    install -Dm755 "${srcdir}/${pkgname}.sh" "${pkgdir}/usr/bin/${pkgname}"
+    sed -i '3s!/opt/mihomo-party/mihomo-party!mihomo-party!' "${pkgdir}/usr/share/applications/${_pkgname}.desktop"
 
     chown -R root:root ${pkgdir}
 }

--- a/aur/mihomo-party/PKGBUILD
+++ b/aur/mihomo-party/PKGBUILD
@@ -35,9 +35,8 @@ package() {
     chmod +x ${pkgdir}/opt/mihomo-party/mihomo-party
     chmod +x ${pkgdir}/opt/mihomo-party/resources/sidecar/mihomo
     chmod +x ${pkgdir}/opt/mihomo-party/resources/sidecar/mihomo-alpha
-    cd ${pkgdir}/../..
-	install -Dm755 "${pkgname}.sh" "${pkgdir}/usr/bin/${pkgname}"
-	sed -i '3s!/opt/mihomo-party/mihomo-party!mihomo-party!' "${pkgdir}/usr/share/applications/${pkgname}.desktop"
+    install -Dm755 "${srcdir}/${pkgname}.sh" "${pkgdir}/usr/bin/${pkgname}"
+    sed -i '3s!/opt/mihomo-party/mihomo-party!mihomo-party!' "${pkgdir}/usr/share/applications/${pkgname}.desktop"
 
     chown -R root:root ${pkgdir}
 }


### PR DESCRIPTION
Some users build software in other directories (such as `/tmp`), and using the `cd ${pkgdir}/../..`  command can cause unexpected problems.