### PR TITLE
Add key controls for app scaling

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -157,7 +157,6 @@ const App: React.FC = () => {
     }
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      console.log('Key pressed:', e.key, 'Ctrl:', e.ctrlKey)
       if (platform !== 'darwin' && e.ctrlKey && e.key === 'q') {
         e.preventDefault()
         quitApp()
@@ -179,10 +178,11 @@ const App: React.FC = () => {
         }
       }
       if (e.ctrlKey) {
-        if (e.key === '-' || e.key === '_') {
+        // "-" Not working Here, key can't be detected
+        if (e.key === '-' || e.key === '_' || e.key === '[') {
           e.preventDefault()
           scaleDown()
-        } else if (e.key === '=' || e.key === '+') {
+        } else if (e.key === '=' || e.key === '+' || e.key === ']') {
           e.preventDefault()
           scaleUp()
         } else if (e.key === '0') {

--- a/src/renderer/src/components/base/base-page.tsx
+++ b/src/renderer/src/components/base/base-page.tsx
@@ -71,7 +71,7 @@ const BasePage = forwardRef<HTMLDivElement, Props>((props, ref) => {
 
         <Divider />
       </div>
-      <div className="content h-[calc(100vh-49px)] overflow-y-auto custom-scrollbar">
+      <div className="content h-[calc(100%-49px)] overflow-y-auto custom-scrollbar">
         {props.children}
       </div>
     </div>

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -3,11 +3,10 @@ import ReactDOM from 'react-dom/client'
 import { HashRouter } from 'react-router-dom'
 import { ThemeProvider as NextThemesProvider } from 'next-themes'
 import { NextUIProvider } from '@nextui-org/react'
-import { init, platform } from '@renderer/utils/init'
+import { init } from '@renderer/utils/init'
 import '@renderer/assets/main.css'
 import App from '@renderer/App'
 import BaseErrorBoundary from './components/base/base-error-boundary'
-import { openDevTools, quitApp } from './utils/ipc'
 import { AppConfigProvider } from './hooks/use-app-config'
 import { ControledMihomoConfigProvider } from './hooks/use-controled-mihomo-config'
 import { OverrideConfigProvider } from './hooks/use-override-config'
@@ -15,31 +14,7 @@ import { ProfileConfigProvider } from './hooks/use-profile-config'
 import { RulesProvider } from './hooks/use-rules'
 import { GroupsProvider } from './hooks/use-groups'
 
-let F12Count = 0
-
 init().then(() => {
-  document.addEventListener('keydown', (e) => {
-    if (platform !== 'darwin' && e.ctrlKey && e.key === 'q') {
-      e.preventDefault()
-      quitApp()
-    }
-    if (platform === 'darwin' && e.metaKey && e.key === 'q') {
-      e.preventDefault()
-      quitApp()
-    }
-    if (e.key === 'Escape') {
-      e.preventDefault()
-      window.close()
-    }
-    if (e.key === 'F12') {
-      e.preventDefault()
-      F12Count++
-      if (F12Count >= 5) {
-        openDevTools()
-        F12Count = 0
-      }
-    }
-  })
   ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <React.StrictMode>
       <NextUIProvider>

--- a/src/renderer/src/pages/connections.tsx
+++ b/src/renderer/src/pages/connections.tsx
@@ -269,7 +269,7 @@ const Connections: React.FC = () => {
         </div>
         <Divider />
       </div>
-      <div className="h-[calc(100vh-100px)] mt-[1px]">
+      <div className="h-[calc(100%-100px)] mt-[1px]">
         <Virtuoso
           data={filteredConnections}
           itemContent={(i, connection) => (

--- a/src/renderer/src/pages/logs.tsx
+++ b/src/renderer/src/pages/logs.tsx
@@ -106,7 +106,7 @@ const Logs: React.FC = () => {
         </div>
         <Divider />
       </div>
-      <div className="h-[calc(100vh-100px)] mt-[1px]">
+      <div className="h-[calc(100%-100px)] mt-[1px]">
         <Virtuoso
           ref={virtuosoRef}
           data={filteredLogs}

--- a/src/renderer/src/pages/proxies.tsx
+++ b/src/renderer/src/pages/proxies.tsx
@@ -208,7 +208,7 @@ const Proxies: React.FC = () => {
           </div>
         </div>
       ) : (
-        <div className="h-[calc(100vh-50px)]">
+        <div className="h-[calc(100%-50px)]">
           <GroupedVirtuoso
             ref={virtuosoRef}
             groupCounts={groupCounts}

--- a/src/renderer/src/pages/rules.tsx
+++ b/src/renderer/src/pages/rules.tsx
@@ -36,7 +36,7 @@ const Rules: React.FC = () => {
         </div>
         <Divider />
       </div>
-      <div className="h-[calc(100vh-100px)] mt-[1px]">
+      <div className="h-[calc(100%-100px)] mt-[1px]">
         <Virtuoso
           data={filteredRules}
           itemContent={(i, rule) => (

--- a/src/shared/types.d.ts
+++ b/src/shared/types.d.ts
@@ -259,6 +259,7 @@ interface IAppConfig {
   siderOrder: string[]
   siderWidth: number
   appTheme: AppTheme
+  appScale: number
   customTheme?: string
   autoCheckUpdate: boolean
   silentStart: boolean


### PR DESCRIPTION
Keys:
- Zoom In `Ctrl + ]`  and `Ctrl + +` 
- Zoom Out `Ctrl + [ ` and `Ctrl + -`
- Reset Zoom `Ctrl + 0`

Known Issues:
- Components like dialogs, dropdowns, and tooltip text do not scale
- The shortcut `Ctrl + -` is currently only detected as `Ctrl`.

Persistence has been implemented.
