### PR TITLE
feat: Add dynamic Dock icon visibility for macOS

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,7 +6,7 @@ import { addProfileItem, getAppConfig, patchAppConfig } from './config'
 import { quitWithoutCore, startCore, stopCore } from './core/manager'
 import { triggerSysProxy } from './sys/sysproxy'
 import icon from '../../resources/icon.png?asset'
-import { createTray } from './resolve/tray'
+import { createTray, hideDockIcon, showDockIcon } from './resolve/tray'
 import { init } from './utils/init'
 import { join } from 'path'
 import { initShortcut } from './resolve/shortcut'
@@ -269,10 +269,21 @@ export async function createWindow(): Promise<void> {
     mainWindow?.webContents.reload()
   })
 
+  mainWindow.on('show', () => {
+    showDockIcon()
+  })
+
   mainWindow.on('close', async (event) => {
     event.preventDefault()
     mainWindow?.hide()
-    const { autoQuitWithoutCore = false, autoQuitWithoutCoreDelay = 60 } = await getAppConfig()
+    const {
+      autoQuitWithoutCore = false,
+      autoQuitWithoutCoreDelay = 60,
+      useDockIcon = true
+    } = await getAppConfig()
+    if (!useDockIcon) {
+      hideDockIcon()
+    }
     if (autoQuitWithoutCore) {
       if (quitTimeout) {
         clearTimeout(quitTimeout)

--- a/src/main/resolve/tray.ts
+++ b/src/main/resolve/tray.ts
@@ -309,7 +309,7 @@ export async function createTray(): Promise<void> {
   tray?.setIgnoreDoubleClickEvents(true)
   if (process.platform === 'darwin') {
     if (!useDockIcon) {
-      app.dock.hide()
+      hideDockIcon()
     }
     ipcMain.on('trayIconUpdate', async (_, png: string) => {
       const image = nativeImage.createFromDataURL(png).resize({ height: 16 })
@@ -386,4 +386,16 @@ export async function closeTrayIcon(): Promise<void> {
     tray.destroy()
   }
   tray = null
+}
+
+export async function showDockIcon(): Promise<void> {
+  if (process.platform === 'darwin' && !app.dock.isVisible()) {
+    await app.dock.show()
+  }
+}
+
+export async function hideDockIcon(): Promise<void> {
+  if (process.platform === 'darwin' && app.dock.isVisible()) {
+    app.dock.hide()
+  }
 }


### PR DESCRIPTION
## 调整内容

来源 https://github.com/mihomo-party-org/mihomo-party/issues/235

调整 macos 下 dock icon 的展示方式，按照以下 4 种情况展示 icon：

1. 如果选择「显示 Dock 图标」时会在 dock 栏中始终展示，无论 app 界面是否显示
2. 如果选择「隐藏 Dock 图标」时会在界面展示时在 dock 栏中展示，在界面关闭（隐藏）时在 dock 栏中隐藏
3. 如果运行 app 时「显示 Dock 图标」，则 dock 栏中 icon 始终展示
4. 如果运行 app 时「隐藏 Dock 图标」，则会在 whenReady 时隐藏 dock 栏中的 icon

以上情况在运行 app 时 icon 显示不受静默启动影响

## 预览

### 界面显示隐藏时 dock icon 动作

https://github.com/user-attachments/assets/73c9c6e6-f399-4798-a199-ee1a5d103042

### 启动 app 时 dock icon 动作

https://github.com/user-attachments/assets/6a9ea076-d14b-4cfa-8c12-562d437ebe1c

