### PR TITLE
fix: Fix missing window at startup due to mihomo core error

### DIFF
--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -145,6 +145,12 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
         reject(i18next.t('tun.error.tunPermissionDenied'))
       }
 
+      if ((process.platform !== 'win32' && str.includes('External controller unix listen error')) ||
+        (process.platform === 'win32' && str.includes('External controller pipe listen error'))
+      ) {
+        reject(i18next.t('mihomo.error.externalControllerListenError'))
+      }
+
       if (
         (process.platform !== 'win32' && str.includes('RESTful API unix listening at')) ||
         (process.platform === 'win32' && str.includes('RESTful API pipe listening at'))

--- a/src/renderer/src/locales/en-US.json
+++ b/src/renderer/src/locales/en-US.json
@@ -139,6 +139,7 @@
   "mihomo.debug": "Debug",
   "mihomo.error.coreStartFailed": "Core start failed",
   "mihomo.error.profileCheckFailed": "Profile Check Failed",
+  "mihomo.error.externalControllerListenError": "External controller listen error",
   "mihomo.findProcess": "Find Process",
   "mihomo.selectFindProcessMode": "Select Process Find Mode",
   "mihomo.strict": "Auto",

--- a/src/renderer/src/locales/fa-IR.json
+++ b/src/renderer/src/locales/fa-IR.json
@@ -139,6 +139,7 @@
   "mihomo.debug": "اشکال‌زدایی",
   "mihomo.error.coreStartFailed": "راه‌اندازی هسته با خطا مواجه شد",
   "mihomo.error.profileCheckFailed": "بررسی پروفایل با خطا مواجه شد",
+  "mihomo.error.externalControllerListenError": "خطا در گوش‌دادن به کنترل‌کننده خارجی",
   "mihomo.findProcess": "یافتن فرآیند",
   "mihomo.selectFindProcessMode": "انتخاب حالت یافتن فرآیند",
   "mihomo.strict": "خودکار",

--- a/src/renderer/src/locales/ru-RU.json
+++ b/src/renderer/src/locales/ru-RU.json
@@ -139,6 +139,7 @@
   "mihomo.debug": "Отладка",
   "mihomo.error.coreStartFailed": "Ошибка запуска ядра",
   "mihomo.error.profileCheckFailed": "Проверка профиля не удалась",
+  "mihomo.error.externalControllerListenError": "Ошибка прослушивания внешнего контроллера",
   "mihomo.findProcess": "Поиск процесса",
   "mihomo.selectFindProcessMode": "Выберите режим поиска процесса",
   "mihomo.strict": "Авто",

--- a/src/renderer/src/locales/zh-CN.json
+++ b/src/renderer/src/locales/zh-CN.json
@@ -139,6 +139,7 @@
   "mihomo.debug": "调试",
   "mihomo.error.coreStartFailed": "内核启动出错",
   "mihomo.error.profileCheckFailed": "配置检查失败",
+  "mihomo.error.externalControllerListenError": "外部控制监听错误",
   "mihomo.findProcess": "查找进程",
   "mihomo.selectFindProcessMode": "选择进程查找模式",
   "mihomo.strict": "自动",


### PR DESCRIPTION
修复当mihomo core因外部控制监听失败而启动失败时程序启动被阻塞，无任何响应的问题