### PR TITLE
feat: add a fixed-interval button for profiles updating

### DIFF
--- a/src/main/config/profile.ts
+++ b/src/main/config/profile.ts
@@ -114,6 +114,7 @@ export async function createProfile(item: Partial<IProfileItem>): Promise<IProfi
     interval: item.interval || 0,
     override: item.override || [],
     useProxy: item.useProxy || false,
+    allowFixedInterval: item.allowFixedInterval || false,
     updated: new Date().getTime()
   } as IProfileItem
   switch (newItem.type) {
@@ -162,7 +163,9 @@ export async function createProfile(item: Partial<IProfileItem>): Promise<IProfi
         newItem.home = headers['profile-web-page-url']
       }
       if (headers['profile-update-interval']) {
-        newItem.interval = parseInt(headers['profile-update-interval']) * 60
+        if (!item.allowFixedInterval) {
+          newItem.interval = parseInt(headers['profile-update-interval']) * 60
+        }
       }
       if (headers['subscription-userinfo']) {
         newItem.extra = parseSubinfo(headers['subscription-userinfo'])

--- a/src/renderer/src/components/profiles/edit-info-modal.tsx
+++ b/src/renderer/src/components/profiles/edit-info-modal.tsx
@@ -108,6 +108,15 @@ const EditInfoModal: React.FC<Props> = (props) => {
                   }}
                 />
               </SettingItem>
+              <SettingItem title={t('profiles.editInfo.fixedInterval')}>
+                <Switch
+                  size="sm"
+                  isSelected={values.allowFixedInterval ?? false}
+                  onValueChange={(v) => {
+                    setValues({ ...values, allowFixedInterval: v })
+                  }}
+                />
+              </SettingItem>
             </>
           )}
           <SettingItem title={t('profiles.editInfo.override.title')}>

--- a/src/renderer/src/locales/en-US.json
+++ b/src/renderer/src/locales/en-US.json
@@ -345,6 +345,7 @@
   "profiles.editInfo.url": "Subscription URL",
   "profiles.editInfo.useProxy": "Use Proxy to Update",
   "profiles.editInfo.interval": "Upd. Interval (min)",
+  "profiles.editInfo.fixedInterval": "Fixed Update Interval",
   "profiles.editInfo.override.title": "Override",
   "profiles.editInfo.override.global": "Global",
   "profiles.editInfo.override.noAvailable": "No available overrides",

--- a/src/renderer/src/locales/fa-IR.json
+++ b/src/renderer/src/locales/fa-IR.json
@@ -350,6 +350,7 @@
   "profiles.editInfo.url": "آدرس اشتراک",
   "profiles.editInfo.useProxy": "استفاده از پراکسی برای به‌روزرسانی",
   "profiles.editInfo.interval": "فاصله به‌روزرسانی (دقیقه)",
+  "profiles.editInfo.fixedInterval": "فاصله به‌روزرسانی ثابت",
   "profiles.editInfo.override.title": "جایگزینی",
   "profiles.editInfo.override.global": "جهانی",
   "profiles.editInfo.override.noAvailable": "جایگزینی در دسترس نیست",

--- a/src/renderer/src/locales/ru-RU.json
+++ b/src/renderer/src/locales/ru-RU.json
@@ -350,6 +350,7 @@
   "profiles.editInfo.url": "URL подписки",
   "profiles.editInfo.useProxy": "Использовать прокси для обновления",
   "profiles.editInfo.interval": "Интервал обн. (мин)",
+  "profiles.editInfo.fixedInterval": "Фиксированный интервал обновления",
   "profiles.editInfo.override.title": "Переопределение",
   "profiles.editInfo.override.global": "Глобальный",
   "profiles.editInfo.override.noAvailable": "Нет доступных переопределений",

--- a/src/renderer/src/locales/zh-CN.json
+++ b/src/renderer/src/locales/zh-CN.json
@@ -350,6 +350,7 @@
   "profiles.editInfo.url": "订阅地址",
   "profiles.editInfo.useProxy": "使用代理更新",
   "profiles.editInfo.interval": "更新间隔（分钟）",
+  "profiles.editInfo.fixedInterval": "固定更新间隔",
   "profiles.editInfo.override.title": "覆写",
   "profiles.editInfo.override.global": "全局",
   "profiles.editInfo.override.noAvailable": "没有可用的覆写",

--- a/src/shared/types.d.ts
+++ b/src/shared/types.d.ts
@@ -461,6 +461,7 @@ interface IProfileItem {
   useProxy?: boolean
   extra?: ISubscriptionUserInfo
   substore?: boolean
+  allowFixedInterval?: boolean
 }
 
 interface ISubStoreSub {


### PR DESCRIPTION
**关联 Issue:**  #525 

**描述:**

此 Pull Request 旨在解决一个许多用户遇到的问题：在手动修改配置文件的更新间隔（`interval`）并保存后，当配置文件自动更新时，该间隔时间会被订阅响应头中的 `profile-update-interval` 值覆盖，导致用户设置的值丢失，回到了默认或提供者指定的值。这对于希望强制使用自定义更新频率的用户来说很不方便。

**解决方案:**

为了解决这个问题，本次提交引入了一个新的配置项 `allowFixedInterval` (布尔值) 到 `IProfileItem` 接口和相应的存储逻辑中。

1.  **后端 (`src/main/config/profile.ts`):**
    * 在创建或更新配置文件的逻辑中，增加了一个判断。只有当 `allowFixedInterval` 为 `false` (或未设置，默认为 `false`) 时，才会使用从订阅头 `profile-update-interval` 获取的值来更新配置文件的 `interval`。
    * 如果 `allowFixedInterval` 设置为 `true`，则会保留用户之前设置的 `interval` 值，忽略订阅头中的间隔建议。

2.  **前端 (`src/renderer/src/components/profiles/edit-info-modal.tsx`):**
    * 在配置编辑信息模态框中，新增了一个名为 “固定更新间隔” (“Fixed Update Interval”) 的开关 (Switch) 组件。
    * 用户可以通过这个开关来启用或禁用 `allowFixedInterval` 标志。

3.  **类型定义 (`src/shared/types.d.ts`):**
    * 更新了 `IProfileItem` 接口，添加了可选的 `allowFixedInterval?: boolean` 字段。

4.  **本地化 (`src/renderer/src/locales/`):**
    * 为新增的 “固定更新间隔” 选项添加了相应的翻译字符串，包括简体中文 (zh-CN)、英文 (en-US)、俄文 (ru-RU) 和波斯文 (fa-IR)。

**测试:**

我已经对这些更改进行了本地测试：
* 创建新配置文件，手动设置间隔，启用“固定更新间隔”，保存后重新打开编辑，确认间隔值被保留。
* 对已有配置文件，编辑并启用“固定更新间隔”，保存并手动触发更新（如果可能），确认间隔值未被订阅头信息覆盖。
* 确认当“固定更新间隔”未启用时，行为与之前一致（即间隔会被订阅头信息更新）。
* 测试了不同语言下的 UI 显示。

目前看来功能运行正常，解决了最初描述的问题，并且没有引入新的问题。

**请求:**

这项改动解决了用户反馈较多的一个痛点，提高了用户自定义配置的灵活性。希望您能审阅此 PR，如果没什么问题，请考虑合并。感谢！
