### PR TITLE
fix: avoid self-proxy loop in Windows TUN

### DIFF
--- a/src/main/core/factory.ts
+++ b/src/main/core/factory.ts
@@ -2,6 +2,7 @@ import { copyFile, mkdir, writeFile, readFile, stat } from 'fs/promises'
 import vm from 'vm'
 import { existsSync, writeFileSync } from 'fs'
 import path from 'path'
+import { isIP } from 'net'
 import {
   getControledMihomoConfig,
   getProfileConfig,
@@ -60,6 +61,49 @@ function processRulesWithOffset(ruleStrings: string[], currentRules: string[], i
   return { normalRules, insertRules: rules }
 }
 
+/**
+ * 确保在启用特定条件（如 Smart 覆写）且启用了 TUN 模式时，将代理服务器的 IP 地址添加到路由排除列表中，以避免路由回环。
+ * 该函数会遍历配置中的所有代理节点，提取出服务器的 IP 地址（支持 IPv4/IPv6），并将其转换为对应的 CIDR 格式（IPv4: /32, IPv6: /128）。
+ *
+ * @param profile 当前的 Mihomo 配置对象
+ * @param enabled 是否需要执行排除逻辑（通常为是否启用了 Smart 核心覆写）
+ * @returns 此次新添加到排除列表中的网段/IP数组
+ */
+function ensureSmartProxyServerTunExclude(profile: IMihomoConfig, enabled: boolean): string[] {
+  if (!enabled || profile.tun?.enable !== true || !Array.isArray(profile.proxies)) return []
+
+  const routeExcludeAddress = Array.isArray(profile.tun['route-exclude-address'])
+    ? [...profile.tun['route-exclude-address']]
+    : []
+  profile.tun['route-exclude-address'] = routeExcludeAddress
+
+  const existing = new Set(routeExcludeAddress.map((address) => address.trim().toLowerCase()))
+  const added: string[] = []
+
+  for (const proxy of profile.proxies as unknown[]) {
+    if (!proxy || typeof proxy !== 'object') continue
+
+    const server = (proxy as Record<string, unknown>).server
+    if (typeof server !== 'string' && typeof server !== 'number') continue
+
+    const host = String(server)
+      .trim()
+      .replace(/^\[(.*)\]$/, '$1')
+      .toLowerCase()
+    const ipVersion = isIP(host)
+    if (!ipVersion) continue
+
+    const cidr = ipVersion === 4 ? `${host}/32` : `${host}/128`
+    if (existing.has(host) || existing.has(cidr)) continue
+
+    routeExcludeAddress.push(cidr)
+    existing.add(cidr)
+    added.push(cidr)
+  }
+
+  return added
+}
+
 export async function generateProfile(): Promise<string | undefined> {
   // 读取最新的配置
   const { current } = await getProfileConfig(true)
@@ -94,6 +138,17 @@ export async function generateProfile(): Promise<string | undefined> {
   }
 
   const profile = deepMerge(currentProfile, controledMihomoConfig)
+  // Smart Override JS 早于受控 TUN 配置合并执行；最终配置写出前再排除代理服务器 IP。
+  const addedProxyServerRouteExcludes = ensureSmartProxyServerTunExclude(
+    profile,
+    overrideIds.smart.length > 0
+  )
+  if (addedProxyServerRouteExcludes.length > 0) {
+    factoryLogger.info(
+      'Added Smart Override proxy server TUN route excludes',
+      addedProxyServerRouteExcludes
+    )
+  }
   // 确保可以拿到基础日志信息
   // 使用 debug 可以调试内核相关问题 `debug/pprof`
   if (['info', 'debug'].includes(profile['log-level']) === false) {


### PR DESCRIPTION
## Summary

- 当 Smart Override 启用且 TUN 已开启时，将代理服务器的字面量 IP 追加到 `tun.route-exclude-address`
- 在追加自动生成的排除项前先克隆 route exclude 列表，避免运行时生成的值反向污染受控的 TUN 设置
- 修改范围限制在最终 profile 生成阶段，也就是受控 Mihomo 配置合并完成之后
- 关联并修复我创建的 issue：#1808  

## Root cause

Smart Override 的执行时机早于受控 TUN 配置合并到运行时 profile 的时机。

在 Windows TUN System stack 下，HY2/Hysteria2 出站到代理服务器本身的流量仍可能被 TUN 捕获，从而形成自代理回环。只有在路由层排除代理服务器 IP，才能避免这类流量重新进入 TUN。

因此，本修复将代理服务器的字面量 IP 排除逻辑放到最终配置合并之后执行，确保生成的运行时配置中包含当前节点实际使用的代理服务器 IP。

## Validation

已执行以下检查：

- `pnpm exec eslint src/main/core/factory.ts`
- `pnpm exec tsc --noEmit -p tsconfig.node.json --composite false`
- `pnpm exec tsc --noEmit -p tsconfig.web.json --composite false`
- `pnpm exec electron-vite build`
- `pnpm exec electron-builder --publish never --win`

手动验证：

- Windows TUN + HY2/Hysteria2 场景下，自代理回环问题已不再复现
- 已在本地自测以下平台构建包：
  - Windows amd64 （Win11 26H1）
  - macOS arm64 （Tahoe）
  - Debian amd64 （Trixie）

上述平台测试均确认修复有效，且未发现对现有功能造成破坏。