### PR TITLE
feat: auto switch GLOBAL group to first proxy node when entering global mode

### DIFF
--- a/src/renderer/src/components/sider/outbound-mode-switcher.tsx
+++ b/src/renderer/src/components/sider/outbound-mode-switcher.tsx
@@ -2,7 +2,12 @@ import { Tabs, Tab } from '@heroui/react'
 import { useAppConfig } from '@renderer/hooks/use-app-config'
 import { useControledMihomoConfig } from '@renderer/hooks/use-controled-mihomo-config'
 import { useGroups } from '@renderer/hooks/use-groups'
-import { mihomoCloseAllConnections, patchMihomoConfig } from '@renderer/utils/ipc'
+import {
+  mihomoChangeProxy,
+  mihomoCloseAllConnections,
+  mihomoProxies,
+  patchMihomoConfig
+} from '@renderer/utils/ipc'
 import { Key } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -17,6 +22,25 @@ const OutboundModeSwitcher: React.FC = () => {
   const onChangeMode = async (mode: OutboundMode): Promise<void> => {
     await patchControledMihomoConfig({ mode })
     await patchMihomoConfig({ mode })
+
+    // Added: 如果切换到全局模式，且 GLOBAL 组当前是 DIRECT，则自动切换到第一个可用节点
+    if (mode === 'global') {
+      try {
+        const proxies = await mihomoProxies()
+        const globalGroup = proxies.proxies['GLOBAL'] as IMihomoGroup
+        if (globalGroup && globalGroup.now === 'DIRECT') {
+          const firstRealNode = globalGroup.all?.find(
+            (name) => name !== 'DIRECT' && name !== 'REJECT'
+          )
+          if (firstRealNode) {
+            await mihomoChangeProxy('GLOBAL', firstRealNode)
+          }
+        }
+      } catch (e) {
+        console.error('Failed to auto switch GLOBAL proxy:', e)
+      }
+    }
+
     if (autoCloseConnection) {
       await mihomoCloseAllConnections()
     }


### PR DESCRIPTION
### Description
When switching to Global mode, the `GLOBAL` proxy group often defaults to `DIRECT`. This can be confusing for new users who find that their traffic is not being proxied after the mode switch.

This PR adds logic to the `OutboundModeSwitcher` component to automatically switch the `GLOBAL` group to the first non-DIRECT/REJECT proxy node when entering global mode, provided that it is currently set to `DIRECT`.

### Changes
- Automatically detects if `GLOBAL` group is set to `DIRECT` when switching to global mode.
- If so, switches to the first valid proxy node in the group.
- Safely handles cases where no proxies are available or IPC calls fail.
