### PR TITLE
fix: inconsistent initial size of the side card for usage

### DIFF
--- a/src/renderer/src/components/sider/usage-card.tsx
+++ b/src/renderer/src/components/sider/usage-card.tsx
@@ -19,7 +19,7 @@ const UsageCard: React.FC<Props> = (props) => {
   const { iconOnly } = props
   const { t } = useTranslation()
   const { appConfig } = useAppConfig()
-  const { usageCardStatus = 'col-span-2', disableAnimations = false } = appConfig || {}
+  const { usageCardStatus = 'col-span-1', disableAnimations = false } = appConfig || {}
   const location = useLocation()
   const navigate = useNavigate()
   const match = location.pathname.includes('/traffic')


### PR DESCRIPTION
用量侧栏卡片的初始大小和设置中的初始设置不一致（手动切换一次后能够同步）

<img width="800" alt="Snipaste_2026-05-13_19-19-25" src="https://github.com/user-attachments/assets/4988918b-92b7-452e-bccb-99dec80e701a" />

设置里默认为 `col-span-1`

https://github.com/mihomo-party-org/clash-party/blob/a4bd41e78418a177be5a7223f06689fc3abaa6e7/src/renderer/src/components/settings/sider-config.tsx#L51

而卡片设置了 `col-span-2`

https://github.com/mihomo-party-org/clash-party/blob/a4bd41e78418a177be5a7223f06689fc3abaa6e7/src/renderer/src/components/sider/usage-card.tsx#L22

#### 现统一改为了  `col-span-1`