### PR TITLE
fix: preserve dns-hijack when profile has DNS config enabled

### DIFF
--- a/src/main/core/factory.ts
+++ b/src/main/core/factory.ts
@@ -125,10 +125,6 @@ export async function generateProfile(): Promise<string | undefined> {
   if (!controlDns) {
     delete controledMihomoConfig.dns
     delete controledMihomoConfig.hosts
-    // 同时清空 TUN 的 DNS 劫持，避免 DNS 请求被拦截但无法处理
-    if (controledMihomoConfig.tun) {
-      controledMihomoConfig.tun = { ...controledMihomoConfig.tun, 'dns-hijack': [] }
-    }
   }
   if (!controlSniff) {
     delete controledMihomoConfig.sniffer
@@ -138,6 +134,10 @@ export async function generateProfile(): Promise<string | undefined> {
   }
 
   const profile = deepMerge(currentProfile, controledMihomoConfig)
+  // 关闭 DNS 覆写时，如果最终配置没有启用的 DNS 配置，清空 dns-hijack 避免请求被劫持但无法处理
+  if (!controlDns && profile.tun && !profile.dns?.enable) {
+    profile.tun = { ...profile.tun, 'dns-hijack': [] }
+  }
   // Smart Override JS 早于受控 TUN 配置合并执行；最终配置写出前再排除代理服务器 IP。
   const addedProxyServerRouteExcludes = ensureSmartProxyServerTunExclude(
     profile,


### PR DESCRIPTION
## Summary

- Fix dns-hijack being unconditionally cleared when DNS override (controlDns) is disabled
- Only clear dns-hijack when the final merged config has no enabled DNS section (`dns.enable` is falsy)
- Users with DNS configured in their subscription/profile will now keep dns-hijack working as expected

## Problem

Commit 0371e11 introduced logic to clear `dns-hijack` when `controlDns=false` to prevent DNS requests from being intercepted without a handler. However, this was too aggressive — it also cleared `dns-hijack` for users who have DNS properly configured in their subscription/profile but don't use the app's DNS override feature.

For example, a user with TUN `dns-hijack: any:53` and DNS configured in their profile would find `dns-hijack` becoming empty in the runtime config after disabling DNS override, breaking DNS resolution through TUN.

## Fix

Move the dns-hijack clearing logic **after** `deepMerge(currentProfile, controledMihomoConfig)`, and only clear it when the final config has no enabled DNS (`!profile.dns?.enable`). This ensures:

- Users with profile DNS configs keep dns-hijack working correctly
- Users without any DNS config still get dns-hijack cleared to prevent broken DNS resolution