### PR TITLE
[codex] fix proxy list layout after visibility toggle

### DIFF
--- a/src/renderer/src/pages/proxies.tsx
+++ b/src/renderer/src/pages/proxies.tsx
@@ -580,7 +580,9 @@ const Proxies: React.FC = () => {
         </div>
       ) : (
         <div className="h-[calc(100vh-50px)]">
+          {/* Reset Virtuoso's measured sizes after toggling unavailable proxy filtering. */}
           <GroupedVirtuoso
+            key={appConfig?.hideUnavailableProxies ? 'hide-unavailable' : 'show-unavailable'}
             ref={virtuosoRef}
             groupCounts={groupCounts}
             defaultItemHeight={80}


### PR DESCRIPTION
## Summary

- remount `GroupedVirtuoso` when unavailable proxy filtering is toggled
- reset stale measured sizes before rendering the updated grouped row layout

## Root cause

Toggling unavailable proxy visibility changes `groupCounts` and the flattened proxy rows. `react-virtuoso` updates the group indices but can retain measurements from the previous grouped layout, so stale offsets remain visible until scrolling triggers a remeasurement.

## User impact

The proxy list refreshes immediately after switching between showing and hiding unavailable nodes, without gaps, misplaced entries, or stale placeholders.

## Validation

- `pnpm review`
- `pnpm exec electron-vite build`
- `git diff --check smart_core...HEAD`

Fixes #1814
