### PR TITLE
fix: keep macOS Dock icon hidden after rapid tray toggles

### DIFF
--- a/src/main/resolve/tray.ts
+++ b/src/main/resolve/tray.ts
@@ -44,6 +44,8 @@ export let tray: Tray | null = null
 let trayMenu: Menu | null = null
 // macOS 流量显示状态，避免异步读取配置导致的时序问题
 let macTrafficIconEnabled = false
+// 避免异步显示 Dock 图标覆盖后续的隐藏请求
+let dockIconShouldBeVisible = true
 type TrayIconStatus = 'white' | 'blue' | 'green' | 'red'
 type TrayImage = Electron.NativeImage | string
 const customTrayIconSize = 16
@@ -545,14 +547,23 @@ export async function closeTrayIcon(): Promise<void> {
 }
 
 export async function showDockIcon(): Promise<void> {
-  if (process.platform === 'darwin' && app.dock && !app.dock.isVisible()) {
-    await app.dock.show()
+  if (process.platform === 'darwin' && app.dock) {
+    dockIconShouldBeVisible = true
+    if (!app.dock.isVisible()) {
+      await app.dock.show()
+    }
+    if (!dockIconShouldBeVisible && app.dock.isVisible()) {
+      app.dock.hide()
+    }
   }
 }
 
 export async function hideDockIcon(): Promise<void> {
-  if (process.platform === 'darwin' && app.dock && app.dock.isVisible()) {
-    app.dock.hide()
+  if (process.platform === 'darwin' && app.dock) {
+    dockIconShouldBeVisible = false
+    if (app.dock.isVisible()) {
+      app.dock.hide()
+    }
   }
 }
 

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -151,7 +151,7 @@ function setupWindowEvents(window: BrowserWindow, config: WindowConfig): void {
       useDockIcon = true
     } = await getAppConfig()
 
-    if (!useDockIcon) {
+    if (!useDockIcon && !window.isVisible()) {
       hideDockIcon()
     }
 


### PR DESCRIPTION
## Summary

- keep the macOS Dock icon state aligned with the latest show/hide request when tray clicks rapidly toggle the main window
- ignore stale close callbacks after the main window has already been reopened

## Root cause

`showDockIcon()` awaits `app.dock.show()`, while `hideDockIcon()` is synchronous. When the tray icon is clicked quickly with `useDockIcon=false`, a close can request a hide before an earlier asynchronous show finishes. The earlier show can then complete last and leave the Dock icon visible. In addition, an older async close callback can finish after the window has reopened and hide the Dock icon for the newer visible state.

## Validation

- `pnpm review`
- `pnpm exec electron-vite build`
- `git diff --check smart_core...HEAD`
- state-machine regression checks for pending show followed by hide, and stale close after reopen

Local validation ran on Node `v25.9.0`; GitHub Actions uses Node 22.

## macOS manual verification

1. Disable **Show Dock Icon** and restart the app. Confirm the Dock icon is hidden after startup.
2. Open and close the main window normally from the menu bar icon. Confirm the Dock icon hides after close.
3. Click the menu bar icon rapidly to toggle the main window repeatedly. Stop with the window closed and confirm the Dock icon stays hidden.
4. Enable **Show Dock Icon** and close the main window. Confirm the Dock icon remains visible as before.

Fixes #1867