### PR TITLE
fix: add WeChat fake-ip compatibility domains

### DIFF
--- a/src/main/core/factory.ts
+++ b/src/main/core/factory.ts
@@ -13,6 +13,7 @@ import {
   getOverrideConfig,
   getAppConfig
 } from '../config'
+import { defaultFakeIpFilter, legacyDefaultFakeIpFilter } from '../../shared/fakeIp'
 import {
   mihomoProfileWorkDir,
   mihomoWorkConfigPath,
@@ -104,6 +105,19 @@ function ensureSmartProxyServerTunExclude(profile: IMihomoConfig, enabled: boole
   return added
 }
 
+// 仅升级未改动过的旧默认值，避免覆盖用户自定义的 fake-ip-filter。
+function shouldUpgradeLegacyFakeIpFilter(profile: IMihomoConfig): boolean {
+  if (profile.dns?.enable === false || profile.dns?.['enhanced-mode'] !== 'fake-ip') return false
+
+  const fakeIpFilter = profile.dns?.['fake-ip-filter']
+  if (!Array.isArray(fakeIpFilter)) return false
+
+  return (
+    fakeIpFilter.length === legacyDefaultFakeIpFilter.length &&
+    fakeIpFilter.every((domain, index) => domain === legacyDefaultFakeIpFilter[index])
+  )
+}
+
 export async function generateProfile(): Promise<string | undefined> {
   // 读取最新的配置
   const { current } = await getProfileConfig(true)
@@ -134,6 +148,12 @@ export async function generateProfile(): Promise<string | undefined> {
   }
 
   const profile = deepMerge(currentProfile, controledMihomoConfig)
+  if (shouldUpgradeLegacyFakeIpFilter(profile)) {
+    profile.dns = {
+      ...profile.dns,
+      'fake-ip-filter': defaultFakeIpFilter
+    }
+  }
   // 关闭 DNS 覆写时，如果最终配置没有启用的 DNS 配置，清空 dns-hijack 避免请求被劫持但无法处理
   if (!controlDns && profile.tun && !profile.dns?.enable) {
     profile.tun = { ...profile.tun, 'dns-hijack': [] }

--- a/src/main/utils/template.ts
+++ b/src/main/utils/template.ts
@@ -1,3 +1,5 @@
+import { defaultFakeIpFilter } from '../../shared/fakeIp'
+
 export const defaultConfig: IAppConfig = {
   core: 'mihomo',
   enableSmartCore: false,
@@ -103,7 +105,7 @@ export const defaultControledMihomoConfig: Partial<IMihomoConfig> = {
     ipv6: false,
     'enhanced-mode': 'fake-ip',
     'fake-ip-range': '198.18.0.1/16',
-    'fake-ip-filter': ['*', '+.lan', '+.local', 'time.*.com', 'ntp.*.com', '+.market.xiaomi.com'],
+    'fake-ip-filter': defaultFakeIpFilter,
     'use-hosts': false,
     'use-system-hosts': false,
     'respect-rules': false,

--- a/src/renderer/src/pages/dns.tsx
+++ b/src/renderer/src/pages/dns.tsx
@@ -9,6 +9,7 @@ import { useAppConfig } from '@renderer/hooks/use-app-config'
 import { mihomoHotReloadConfig } from '@renderer/utils/ipc'
 import React, { Key, ReactNode, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { defaultFakeIpFilter } from '../../../shared/fakeIp'
 
 const DNS: React.FC = () => {
   const { t } = useTranslation()
@@ -20,14 +21,7 @@ const DNS: React.FC = () => {
     enable = true,
     ipv6 = false,
     'fake-ip-range': fakeIPRange = '198.18.0.1/16',
-    'fake-ip-filter': fakeIPFilter = [
-      '*',
-      '+.lan',
-      '+.local',
-      'time.*.com',
-      'ntp.*.com',
-      '+.market.xiaomi.com'
-    ],
+    'fake-ip-filter': fakeIPFilter = defaultFakeIpFilter,
     'fake-ip-filter-mode': fakeIPFilterMode = 'blacklist',
     'enhanced-mode': enhancedMode = 'fake-ip',
     'use-hosts': useHosts = false,

--- a/src/shared/fakeIp.ts
+++ b/src/shared/fakeIp.ts
@@ -1,0 +1,28 @@
+// 历史默认 fake-ip-filter，用来识别“用户未修改过旧默认值”的场景。
+export const legacyDefaultFakeIpFilter = [
+  '*',
+  '+.lan',
+  '+.local',
+  'time.*.com',
+  'ntp.*.com',
+  '+.market.xiaomi.com'
+]
+
+// 为微信/企业微信图片等资源补充直连解析域名，避免 TUN + fake-ip 下上传异常。
+export const wechatFakeIpCompatDomains = [
+  'mmbiz.qpic.cn',
+  'wxaintpcos.wxqcloud.qq.com.cn',
+  '+.qpic.cn',
+  '+.wxqcloud.qq.com.cn',
+  '+.servicewechat.com',
+  '+.weixin.qq.com',
+  '+.wxs.qq.com',
+  '+.res.wx.qq.com',
+  '+.wework.qpic.cn'
+]
+
+// 当前应用内置的默认 fake-ip-filter。
+export const defaultFakeIpFilter = [
+  ...legacyDefaultFakeIpFilter,
+  ...wechatFakeIpCompatDomains
+]


### PR DESCRIPTION
## Summary
- describe the affected scenario: on Windows, when TUN is enabled and DNS uses `fake-ip`, WeChat can still send text messages but image uploads may fail or hang
- add shared fake-ip compatibility domain constants for WeChat resources
- include the WeChat compatibility domains in the default fake-ip filter
- upgrade runtime configs that still use the legacy fake-ip default list without overriding user-customized filters

## Root cause
The legacy default `fake-ip-filter` misses several WeChat image and resource domains, so those requests may still be resolved to fake IPs in Windows TUN + `fake-ip` mode and break image uploads.

## Testing
- pnpm run typecheck
- pnpm run lint:check