### PR TITLE
ci: publish winget releases to Clash Party package id (#1686)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -658,7 +658,7 @@ jobs:
       - name: Submit to Winget
         uses: vedantmgoyal9/winget-releaser@main
         with:
-          identifier: Mihomo-Party.Mihomo-Party
+          identifier: Mihomo-Party.Clash-Party
           version: ${{env.VERSION}}
           release-tag: v${{env.VERSION}}
           installers-regex: 'clash-party-windows-.*setup\.exe$'


### PR DESCRIPTION
## Summary
- update the release workflow winget identifier to 0Mihomo-Party.Clash-Party0
- stop publishing new releases to the legacy 0Mihomo-Party.Mihomo-Party0 package id

## Verification
- git grep -n -E 'Mihomo-Party\\.Mihomo-Party|Mihomo-Party\\.Clash-Party|winget' -- .github README.md package.json electron-builder.yml scripts
- git diff --check smart_core...HEAD