### PR TITLE
fix: normalize Windows core log encoding (#1021)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "checksum": "node scripts/checksum.mjs",
     "copy-legacy": "node scripts/copy-legacy-artifacts.mjs",
     "test-copy-legacy": "node scripts/test-copy-legacy.mjs",
+    "test:core-log-encoding": "pnpm exec tsx scripts/test-core-log-encoding.ts",
     "telegram": "node scripts/telegram.mjs release",
     "telegram:dev": "node scripts/telegram.mjs dev",
     "artifact": "node scripts/artifact.mjs",

--- a/scripts/test-core-log-encoding.ts
+++ b/scripts/test-core-log-encoding.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { finished } from 'node:stream/promises'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import iconv from 'iconv-lite'
+import { createDecodedCappedLogWritableStream } from '../src/main/utils/logFile'
+
+async function main(): Promise<void> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'core-log-encoding-'))
+  const logPath = path.join(tempDir, 'core.log')
+
+  try {
+    const expected = '中文日志 ready\n第二行'
+    const encoded = iconv.encode(expected, 'gbk')
+    const stream = createDecodedCappedLogWritableStream(logPath, 'gbk')
+    const emitted: string[] = []
+
+    stream.on('text', (text) => emitted.push(text))
+    stream.write(encoded.subarray(0, 3))
+    stream.end(encoded.subarray(3))
+    await finished(stream)
+
+    assert.equal(emitted.join(''), expected)
+    assert.equal(await readFile(logPath, 'utf8'), expected)
+    assert.deepEqual(await readFile(logPath), Buffer.from(expected, 'utf8'))
+
+    process.stdout.write('core log encoding normalization ok\n')
+  } finally {
+    await rm(tempDir, { recursive: true, force: true })
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -4,6 +4,7 @@ import { promisify } from 'util'
 import path from 'path'
 import os from 'os'
 import { existsSync } from 'fs'
+import iconv from 'iconv-lite'
 import chokidar, { FSWatcher } from 'chokidar'
 import { app, ipcMain } from 'electron'
 import { mainWindow } from '../window'
@@ -30,7 +31,10 @@ import { ensureRuntimeFiles, safeShowErrorBox } from '../utils/init'
 import { parseAgeSecretKeys } from '../utils/age'
 import i18next from '../../shared/i18n'
 import { managerLogger } from '../utils/logger'
-import { createCappedLogWritableStream } from '../utils/logFile'
+import {
+  createCappedLogWritableStream,
+  createDecodedCappedLogWritableStream
+} from '../utils/logFile'
 import {
   startMihomoTraffic,
   startMihomoConnections,
@@ -77,6 +81,7 @@ export { getDefaultDevice } from './dns'
 
 const execFilePromise = promisify(execFile)
 const ctlParam = process.platform === 'win32' ? '-ext-ctl-pipe' : '-ext-ctl-unix'
+const WINDOWS_CORE_LOG_ENCODING = 'gbk'
 
 // 核心进程状态
 let child: ChildProcess | null = null
@@ -272,8 +277,14 @@ function spawnCoreProcess(config: CoreConfig): ChildProcess {
   }
 
   if (!detached) {
-    const stdout = createCappedLogWritableStream(coreLogPath)
-    const stderr = createCappedLogWritableStream(coreLogPath)
+    const stdout =
+      process.platform === 'win32'
+        ? createDecodedCappedLogWritableStream(coreLogPath, WINDOWS_CORE_LOG_ENCODING)
+        : createCappedLogWritableStream(coreLogPath)
+    const stderr =
+      process.platform === 'win32'
+        ? createDecodedCappedLogWritableStream(coreLogPath, WINDOWS_CORE_LOG_ENCODING)
+        : createCappedLogWritableStream(coreLogPath)
     proc.stdout?.pipe(stdout)
     proc.stderr?.pipe(stderr)
   }
@@ -288,6 +299,19 @@ function setupCoreListeners(
   resolve: (value: Promise<void>[]) => void,
   reject: (reason: unknown) => void
 ): void {
+  const stdoutDecoder =
+    process.platform === 'win32' ? iconv.getDecoder(WINDOWS_CORE_LOG_ENCODING) : null
+  let stdoutTail = ''
+  let tunPermissionHandled = false
+  let controllerErrorHandled = false
+  let apiReadyHandled = false
+  let providerReadyHandled = false
+  let startResolved = false
+  let resolveProviderReady!: () => void
+  const providerReadyPromise = new Promise<void>((innerResolve) => {
+    resolveProviderReady = innerResolve
+  })
+
   proc.on('close', async (code, signal) => {
     managerLogger.info(`Core closed, code: ${code}, signal: ${signal}`)
 
@@ -310,10 +334,13 @@ function setupCoreListeners(
   })
 
   proc.stdout?.on('data', async (data) => {
-    const str = data.toString()
+    const text = stdoutDecoder ? stdoutDecoder.write(data) : data.toString()
+    const str = stdoutTail + text
+    stdoutTail = str.slice(-512)
 
     // TUN 权限错误
-    if (str.includes('configure tun interface: operation not permitted')) {
+    if (!tunPermissionHandled && str.includes('configure tun interface: operation not permitted')) {
+      tunPermissionHandled = true
       patchControledMihomoConfig({ tun: { enable: false } })
       mainWindow?.webContents.send('controledMihomoConfigUpdated')
       ipcMain.emit('updateTrayMenu')
@@ -326,7 +353,8 @@ function setupCoreListeners(
       (process.platform !== 'win32' && str.includes('External controller unix listen error')) ||
       (process.platform === 'win32' && str.includes('External controller pipe listen error'))
 
-    if (isControllerError) {
+    if (!controllerErrorHandled && isControllerError) {
+      controllerErrorHandled = true
       managerLogger.error('External controller listen error detected:', str)
 
       if (process.platform === 'win32') {
@@ -348,29 +376,12 @@ function setupCoreListeners(
       (process.platform !== 'win32' && str.includes('RESTful API unix listening at')) ||
       (process.platform === 'win32' && str.includes('RESTful API pipe listening at'))
 
-    if (isApiReady) {
-      resolve([
-        new Promise((innerResolve) => {
-          proc.stdout?.on('data', async (innerData) => {
-            if (
-              innerData
-                .toString()
-                .toLowerCase()
-                .includes('start initial compatible provider default')
-            ) {
-              try {
-                mainWindow?.webContents.send('groupsUpdated')
-                mainWindow?.webContents.send('rulesUpdated')
-                await uploadRuntimeConfig()
-              } catch {
-                // ignore
-              }
-              await patchMihomoConfig({ 'log-level': logLevel })
-              innerResolve()
-            }
-          })
-        })
-      ])
+    if (!apiReadyHandled && isApiReady) {
+      apiReadyHandled = true
+      if (!startResolved) {
+        startResolved = true
+        resolve([providerReadyPromise])
+      }
 
       await waitForCoreReady()
       await getAxios(true)
@@ -381,6 +392,23 @@ function setupCoreListeners(
         startMihomoMemory()
       ])
       retry = 10
+    }
+
+    if (
+      apiReadyHandled &&
+      !providerReadyHandled &&
+      str.toLowerCase().includes('start initial compatible provider default')
+    ) {
+      providerReadyHandled = true
+      try {
+        mainWindow?.webContents.send('groupsUpdated')
+        mainWindow?.webContents.send('rulesUpdated')
+        await uploadRuntimeConfig()
+      } catch {
+        // ignore
+      }
+      await patchMihomoConfig({ 'log-level': logLevel })
+      resolveProviderReady()
     }
   })
 }

--- a/src/main/utils/logFile.ts
+++ b/src/main/utils/logFile.ts
@@ -1,5 +1,6 @@
 import { appendFile, open, stat, writeFile } from 'fs/promises'
 import { Writable } from 'stream'
+import iconv from 'iconv-lite'
 
 const MB = 1024 * 1024
 const DEFAULT_MAX_LOG_FILE_SIZE_MB = 10
@@ -171,9 +172,59 @@ class CappedLogWritable extends Writable {
   }
 }
 
+export interface DecodedCappedLogWritable extends Writable {
+  on(event: 'text', listener: (text: string) => void): this
+}
+
+class DecodedCappedLogWritableStream extends Writable implements DecodedCappedLogWritable {
+  private readonly resolvePath: () => string
+  private readonly maxBytes: number
+  private readonly decoder: iconv.DecoderStream
+
+  constructor(filePath: LogFilePath, sourceEncoding: string, maxBytes: number) {
+    super()
+    this.resolvePath = typeof filePath === 'function' ? filePath : (): string => filePath
+    this.maxBytes = maxBytes
+    this.decoder = iconv.getDecoder(sourceEncoding)
+  }
+
+  _write(
+    chunk: Buffer | string,
+    encoding: BufferEncoding,
+    callback: (error?: Error | null) => void
+  ): void {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding)
+    this.writeDecodedText(this.decoder.write(buffer)).then(
+      () => callback(),
+      (error) => callback(error as Error)
+    )
+  }
+
+  _final(callback: (error?: Error | null) => void): void {
+    this.writeDecodedText(this.decoder.end() ?? '').then(
+      () => callback(),
+      (error) => callback(error as Error)
+    )
+  }
+
+  private async writeDecodedText(text: string): Promise<void> {
+    if (!text) return
+    this.emit('text', text)
+    await appendToFileWithLimit(this.resolvePath(), text, this.maxBytes)
+  }
+}
+
 export function createCappedLogWritableStream(
   filePath: LogFilePath,
   maxBytes = getGlobalMaxLogFileSizeBytes()
 ): Writable {
   return new CappedLogWritable(filePath, maxBytes)
+}
+
+export function createDecodedCappedLogWritableStream(
+  filePath: LogFilePath,
+  sourceEncoding: string,
+  maxBytes = getGlobalMaxLogFileSizeBytes()
+): DecodedCappedLogWritable {
+  return new DecodedCappedLogWritableStream(filePath, sourceEncoding, maxBytes)
 }


### PR DESCRIPTION
## Summary\n- normalize Windows core stdout/stderr from GBK/CP936 to UTF-8 before writing core.log\n- keep readiness and error detection on the same decoded stdout stream, including split chunk handling\n- add a focused 	sx verification script for split GBK chunks written as UTF-8\n\n## Validation\n- pnpm review\n- pnpm exec electron-vite build\n- pnpm exec tsx scripts/test-core-log-encoding.ts\n- git diff --check smart_core...HEAD