### PR TITLE
fix: sanitize restored window state

### DIFF
--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -47,19 +47,21 @@ function saveWindowState(window: BrowserWindow): void {
 
 function ensureVisibleOnScreen(state: WindowState): WindowState {
   const { width, height } = normalizeWindowSize(state)
+  const x = Number.isFinite(state.x) ? state.x : undefined
+  const y = Number.isFinite(state.y) ? state.y : undefined
   const displays = screen.getAllDisplays()
   const visible = displays.some((d) => {
     const b = d.bounds
     return (
-      state.x !== undefined &&
-      state.y !== undefined &&
-      state.x < b.x + b.width &&
-      state.x + width > b.x &&
-      state.y < b.y + b.height &&
-      state.y + height > b.y
+      x !== undefined &&
+      y !== undefined &&
+      x < b.x + b.width &&
+      x + width > b.x &&
+      y < b.y + b.height &&
+      y + height > b.y
     )
   })
-  const safeState = { ...state, width, height }
+  const safeState = { ...state, width, height, x, y }
   return visible ? safeState : { width, height }
 }
 

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -17,12 +17,23 @@ interface WindowState {
   isMaximized?: boolean
 }
 
+const defaultWindowState: WindowState = { width: 800, height: 600 }
+
+function normalizeWindowSize(state: WindowState): Pick<WindowState, 'width' | 'height'> {
+  const width = Number.isFinite(state.width) ? state.width : defaultWindowState.width
+  const height = Number.isFinite(state.height) ? state.height : defaultWindowState.height
+  return {
+    width: Math.max(width, defaultWindowState.width),
+    height: Math.max(height, defaultWindowState.height)
+  }
+}
+
 function loadWindowState(): WindowState {
   try {
     const raw = readFileSync(join(dataDir(), 'window-state.json'), 'utf-8')
     return JSON.parse(raw)
   } catch {
-    return { width: 800, height: 600 }
+    return defaultWindowState
   }
 }
 
@@ -35,19 +46,21 @@ function saveWindowState(window: BrowserWindow): void {
 }
 
 function ensureVisibleOnScreen(state: WindowState): WindowState {
+  const { width, height } = normalizeWindowSize(state)
   const displays = screen.getAllDisplays()
   const visible = displays.some((d) => {
     const b = d.bounds
     return (
       state.x !== undefined &&
       state.y !== undefined &&
-      state.x >= b.x &&
-      state.y >= b.y &&
       state.x < b.x + b.width &&
-      state.y < b.y + b.height
+      state.x + width > b.x &&
+      state.y < b.y + b.height &&
+      state.y + height > b.y
     )
   })
-  return visible ? state : { width: state.width, height: state.height }
+  const safeState = { ...state, width, height }
+  return visible ? safeState : { width, height }
 }
 
 export let mainWindow: BrowserWindow | null = null


### PR DESCRIPTION
## Summary

Fixes #1930.

This sanitizes the restored main-window state before creating the Electron `BrowserWindow`. A stale or malformed `window-state.json` can otherwise restore a too-small window or a window placed at the edge of the desktop.

## Changes

- Reuse a single default main-window size of 800x600.
- Clamp restored width and height to the app's minimum window size.
- Treat a saved window position as valid only when the restored window rectangle intersects an available display.
- Fall back to Electron's default placement when the saved position is off-screen.

## Validation

- `pnpm run typecheck:node`
- `pnpm exec prettier --check src/main/window.ts`
- `pnpm exec eslint src/main/window.ts`
- `git diff --check`
- Pre-commit hook: `pnpm run format:check`, `pnpm run lint:check`, `pnpm run typecheck`