### PR TITLE
feat: add deeplink core restart action (#1620)

### DIFF
--- a/src/main/deeplink.ts
+++ b/src/main/deeplink.ts
@@ -1,13 +1,30 @@
 import { Notification } from 'electron'
 import i18next from 'i18next'
 import { addProfileItem } from './config'
+import { restartCore } from './core/manager'
 import { mainWindow } from './window'
 import { safeShowErrorBox } from './utils/init'
 
-export async function handleDeepLink(url: string): Promise<void> {
-  if (!url.startsWith('clash://') && !url.startsWith('mihomo://')) return
+function parseDeepLink(url: string): URL | undefined {
+  if (!url.startsWith('clash://') && !url.startsWith('mihomo://')) return undefined
 
-  const urlObj = new URL(url)
+  try {
+    return new URL(url)
+  } catch {
+    return undefined
+  }
+}
+
+export function shouldShowWindowForDeepLink(url: string): boolean {
+  const urlObj = parseDeepLink(url)
+  if (!urlObj) return true
+  return urlObj?.host === 'install-config'
+}
+
+export async function handleDeepLink(url: string): Promise<void> {
+  const urlObj = parseDeepLink(url)
+  if (!urlObj) return
+
   switch (urlObj.host) {
     case 'install-config': {
       try {
@@ -25,6 +42,14 @@ export async function handleDeepLink(url: string): Promise<void> {
         new Notification({ title: i18next.t('profiles.notification.importSuccess') }).show()
       } catch (e) {
         safeShowErrorBox('profiles.error.importFailed', `${url}\n${e}`)
+      }
+      break
+    }
+    case 'restart-core': {
+      try {
+        await restartCore()
+      } catch (e) {
+        safeShowErrorBox('mihomo.error.coreStartFailed', `${e}`)
       }
       break
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -29,7 +29,7 @@ import {
   triggerMainWindow,
   closeMainWindow
 } from './window'
-import { handleDeepLink } from './deeplink'
+import { handleDeepLink, shouldShowWindowForDeepLink } from './deeplink'
 import {
   fixUserDataPermissions,
   setupPlatformSpecifics,
@@ -120,15 +120,21 @@ initHardwareAcceleration()
 setupAppLifecycle()
 
 app.on('second-instance', async (_event, commandline) => {
-  showMainWindow()
   const url = commandline.pop()
   if (url) {
+    if (shouldShowWindowForDeepLink(url)) {
+      showMainWindow()
+    }
     await handleDeepLink(url)
+  } else {
+    showMainWindow()
   }
 })
 
 app.on('open-url', async (_event, url) => {
-  showMainWindow()
+  if (shouldShowWindowForDeepLink(url)) {
+    showMainWindow()
+  }
   await handleDeepLink(url)
 })
 


### PR DESCRIPTION
## Summary
- add clash://restart-core and mihomo://restart-core deeplink actions
- route those actions through the same application-level estartCore() path used by the core card restart button
- keep external restart deeplinks silent while preserving window activation for config imports and ordinary second-instance launches

## Verification
- pnpm review
- pnpm exec electron-vite build
- git diff --check smart_core...HEAD

## Notes
- Manual OS-level URL scheme invocation was not run in this environment.