### PR TITLE
feat: add rule view to traffic usage page

### DIFF
--- a/src/renderer/src/hooks/use-traffic-logger.ts
+++ b/src/renderer/src/hooks/use-traffic-logger.ts
@@ -141,12 +141,19 @@ export function useTrafficLogger(enabled = true): void {
         if (uploadDelta === 0 && downloadDelta === 0) continue
 
         hasDeltas = true
+        // Payload: "TYPE: PAYLOAD", Non-payload: "TYPE", Non-rule "Unknown"
+        const rule = conn.rule
+          ? conn.rulePayload
+            ? `${conn.rule}: ${conn.rulePayload}`
+            : conn.rule
+          : 'Unknown'
         logBufferRef.current.push({
           timestamp: now,
           sourceIP: conn.metadata.sourceIP || 'Inner',
           host: conn.metadata.host || conn.metadata.destinationIP || 'Unknown',
           process: conn.metadata.process || 'Unknown',
           outbound: conn.chains?.[0] || 'DIRECT',
+          rule,
           upload: uploadDelta,
           download: downloadDelta
         })

--- a/src/renderer/src/locales/en-US.json
+++ b/src/renderer/src/locales/en-US.json
@@ -391,6 +391,7 @@
   "traffic.view.host": "Hosts",
   "traffic.view.outbound": "Proxies",
   "traffic.view.process": "Processes",
+  "traffic.view.rule": "Rules",
   "traffic.timeRange.1h": "1h",
   "traffic.timeRange.24h": "24h",
   "traffic.timeRange.7d": "7d",

--- a/src/renderer/src/locales/fa-IR.json
+++ b/src/renderer/src/locales/fa-IR.json
@@ -366,6 +366,7 @@
   "traffic.view.host": "هاست‌ها",
   "traffic.view.outbound": "پروکسی‌ها",
   "traffic.view.process": "فرآیندها",
+  "traffic.view.rule": "قوانین",
   "traffic.timeRange.1h": "۱ساعت",
   "traffic.timeRange.24h": "۲۴ساعت",
   "traffic.timeRange.7d": "۷روز",

--- a/src/renderer/src/locales/ru-RU.json
+++ b/src/renderer/src/locales/ru-RU.json
@@ -370,6 +370,7 @@
   "traffic.view.host": "Хосты",
   "traffic.view.outbound": "Прокси",
   "traffic.view.process": "Процессы",
+  "traffic.view.rule": "Правила",
   "traffic.timeRange.1h": "1ч",
   "traffic.timeRange.24h": "24ч",
   "traffic.timeRange.7d": "7д",

--- a/src/renderer/src/locales/zh-CN.json
+++ b/src/renderer/src/locales/zh-CN.json
@@ -391,6 +391,7 @@
   "traffic.view.host": "域名",
   "traffic.view.outbound": "代理",
   "traffic.view.process": "进程",
+  "traffic.view.rule": "规则",
   "traffic.timeRange.1h": "1 小时",
   "traffic.timeRange.24h": "24 小时",
   "traffic.timeRange.7d": "7 天",

--- a/src/renderer/src/locales/zh-TW.json
+++ b/src/renderer/src/locales/zh-TW.json
@@ -391,6 +391,7 @@
   "traffic.view.host": "網域",
   "traffic.view.outbound": "代理",
   "traffic.view.process": "程序",
+  "traffic.view.rule": "規則",
   "traffic.timeRange.1h": "1 小時",
   "traffic.timeRange.24h": "24 小時",
   "traffic.timeRange.7d": "7 天",

--- a/src/renderer/src/pages/traffic.tsx
+++ b/src/renderer/src/pages/traffic.tsx
@@ -145,7 +145,8 @@ const TrafficPage: React.FC = () => {
     sourceIP: t('traffic.view.sourceIP'),
     host: t('traffic.view.host'),
     outbound: t('traffic.view.outbound'),
-    process: t('traffic.view.process')
+    process: t('traffic.view.process'),
+    rule: t('traffic.view.rule')
   }
 
   return (

--- a/src/renderer/src/utils/dataUsage.ts
+++ b/src/renderer/src/utils/dataUsage.ts
@@ -1,6 +1,6 @@
 import { db } from '@renderer/utils/db'
 
-export type DataUsageType = 'sourceIP' | 'host' | 'outbound' | 'process'
+export type DataUsageType = 'sourceIP' | 'host' | 'outbound' | 'process' | 'rule'
 
 export interface AggregatedData {
   label: string
@@ -26,7 +26,9 @@ export async function getAggregatedData(
           ? log.host
           : type === 'outbound'
             ? log.outbound
-            : log.process
+            : type === 'process'
+              ? log.process
+              : log.rule || 'Unknown'
 
     const existing = map.get(label)
     if (existing) {
@@ -60,7 +62,9 @@ export async function getSubStatsByHost(
       ? log.sourceIP === label
       : dimension === 'outbound'
         ? log.outbound === label
-        : log.process === label
+        : dimension === 'process'
+          ? log.process === label
+          : (log.rule || 'Unknown') === label
   )
 
   const map = new Map<string, AggregatedData>()
@@ -129,7 +133,9 @@ export async function getProxyStatsByHost(
       ? log.sourceIP === parentLabel
       : dimension === 'process'
         ? log.process === parentLabel
-        : log.outbound === parentLabel
+        : dimension === 'outbound'
+          ? log.outbound === parentLabel
+          : (log.rule || 'Unknown') === parentLabel
   })
 
   const map = new Map<string, AggregatedData>()

--- a/src/renderer/src/utils/db.ts
+++ b/src/renderer/src/utils/db.ts
@@ -5,13 +5,14 @@ export interface DataUsageLog {
   host: string
   outbound: string
   process: string
+  rule: string
   upload: number
   download: number
 }
 
 const DB_NAME = 'clashparty_db'
 const STORE_NAME = 'data_usage_logs'
-const DB_VERSION = 1
+const DB_VERSION = 2
 
 export class DataUsageDB {
   private db: IDBDatabase | null = null
@@ -24,13 +25,22 @@ export class DataUsageDB {
 
       request.onupgradeneeded = (event) => {
         const db = (event.target as IDBOpenDBRequest).result
+        const oldVersion = event.oldVersion
         if (!db.objectStoreNames.contains(STORE_NAME)) {
+          // Fresh installation
           const store = db.createObjectStore(STORE_NAME, { keyPath: 'id', autoIncrement: true })
           store.createIndex('timestamp', 'timestamp', { unique: false })
           store.createIndex('sourceIP', 'sourceIP', { unique: false })
           store.createIndex('host', 'host', { unique: false })
           store.createIndex('outbound', 'outbound', { unique: false })
           store.createIndex('process', 'process', { unique: false })
+          store.createIndex('rule', 'rule', { unique: false })
+        } else if (oldVersion < 2) {
+          // Update
+          const store = db.transaction(STORE_NAME, 'versionchange').objectStore(STORE_NAME)
+          if (!store.indexNames.contains('rule')) {
+            store.createIndex('rule', 'rule', { unique: false })
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- add a new "Rules" tab to the traffic usage page to show which rules matched which hosts
- collect `rule` + `rulePayload` from mihomo `/connections` and store as a combined string (`TYPE: PAYLOAD` / `TYPE` / `Unknown`)
- extend `DataUsageLog` schema with a `rule` field and migrate IndexedDB from v1 to v2 (legacy records fall back to "Unknown")
- extend `DataUsageType` with `'rule'` and update aggregation functions to support rule → host → proxy drill-down
- add `traffic.view.rule` i18n entries for all 5 locales (en-US, zh-CN, zh-TW, ru-RU, fa-IR)

## Verification
- pnpm run typecheck:web
- pnpm run typecheck:node
- pnpm run lint:check

## Notes
- TrafficRankings, TrafficTrendChart, and TrafficDetailsTable require no changes — they are dimension-agnostic and the details table auto-shows "Hosts" for the rule view
- Legacy v1 records without a `rule` field are grouped under "Unknown" in the rule view

<img width="1174" height="1077" alt="image" src="https://github.com/user-attachments/assets/00c8af35-7d09-4211-8f7f-048bbce30312" />