### PR TITLE
feat: show friendly Windows app names in connections

### DIFF
--- a/src/main/utils/appName.test.ts
+++ b/src/main/utils/appName.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileAsync, existsSync } = vi.hoisted(() => ({
+  execFileAsync: vi.fn(),
+  existsSync: vi.fn()
+}))
+
+vi.mock('fs', () => ({
+  default: {
+    existsSync,
+    readFileSync: vi.fn()
+  }
+}))
+
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+  spawnSync: vi.fn()
+}))
+
+vi.mock('util', () => ({
+  promisify: () => execFileAsync
+}))
+
+vi.mock('./icon', () => ({
+  findBestAppPath: vi.fn(),
+  isIOSApp: vi.fn()
+}))
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+}
+
+beforeEach(() => {
+  setPlatform('win32')
+  existsSync.mockReset()
+  execFileAsync.mockReset()
+  vi.resetModules()
+})
+
+afterEach(() => {
+  if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform)
+})
+
+describe('getAppName on Windows', () => {
+  it('reads the executable file description', async () => {
+    existsSync.mockReturnValue(true)
+    execFileAsync.mockResolvedValue({ stdout: 'Google Chrome\r\n' })
+    const { getAppName } = await import('./appName')
+
+    await expect(getAppName("C:\\Program Files\\Publisher's App\\application.exe")).resolves.toBe(
+      'Google Chrome'
+    )
+
+    const args = execFileAsync.mock.calls[0][1] as string[]
+    expect(args[3]).toContain("Publisher''s App")
+    expect(args[3]).toContain('VersionInfo.FileDescription')
+    expect(args[3]).toContain('VersionInfo.ProductName')
+  })
+
+  it('skips metadata lookup when the executable does not exist', async () => {
+    existsSync.mockReturnValue(false)
+    const { getAppName } = await import('./appName')
+
+    await expect(getAppName('C:\\missing.exe')).resolves.toBe('')
+    expect(execFileAsync).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/utils/appName.ts
+++ b/src/main/utils/appName.ts
@@ -1,10 +1,45 @@
 import fs from 'fs'
 import path from 'path'
-import { spawnSync } from 'child_process'
+import { execFile, spawnSync } from 'child_process'
+import { promisify } from 'util'
 import plist from 'plist'
 import { findBestAppPath, isIOSApp } from './icon'
 
+const execFileAsync = promisify(execFile)
+
+async function getWindowsAppName(appPath: string): Promise<string> {
+  if (!fs.existsSync(appPath)) return ''
+
+  const escapedPath = appPath.replace(/'/g, "''")
+  const script = [
+    '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8',
+    `$item = Get-Item -LiteralPath '${escapedPath}' -ErrorAction Stop`,
+    '$name = $item.VersionInfo.FileDescription',
+    'if ([string]::IsNullOrWhiteSpace($name)) { $name = $item.VersionInfo.ProductName }',
+    '$name'
+  ].join('; ')
+
+  try {
+    const { stdout } = await execFileAsync(
+      'powershell',
+      ['-NoProfile', '-NonInteractive', '-Command', script],
+      {
+        encoding: 'utf8',
+        timeout: 5000,
+        windowsHide: true
+      }
+    )
+    return stdout.trim()
+  } catch {
+    return ''
+  }
+}
+
 export async function getAppName(appPath: string): Promise<string> {
+  if (process.platform === 'win32') {
+    return getWindowsAppName(appPath)
+  }
+
   if (process.platform === 'darwin') {
     try {
       const targetPath = findBestAppPath(appPath)

--- a/src/renderer/src/pages/connections.tsx
+++ b/src/renderer/src/pages/connections.tsx
@@ -319,7 +319,7 @@ const Connections: React.FC = () => {
   }, [])
 
   useEffect(() => {
-    if (!displayIcon || findProcessMode === 'off') return
+    if ((!displayIcon && !displayAppName) || findProcessMode === 'off') return
 
     const visiblePaths = new Set<string>()
     const otherPaths = new Set<string>()
@@ -327,12 +327,14 @@ const Connections: React.FC = () => {
     const visibleConnections = filteredConnectionsRef.current.slice(0, 20)
     visibleConnections.forEach((c) => {
       const path = c.metadata.processPath || ''
+      if (!path) return
       visiblePaths.add(path)
     })
 
     const collectPaths = (connections: IMihomoConnectionDetail[]) => {
       for (const c of connections) {
         const path = c.metadata.processPath || ''
+        if (!path) continue
         if (!visiblePaths.has(path)) {
           otherPaths.add(path)
         }
@@ -366,14 +368,14 @@ const Connections: React.FC = () => {
     }
 
     visiblePaths.forEach((path) => {
-      loadIcon(path, true)
+      if (displayIcon) loadIcon(path, true)
       if (displayAppName) loadAppName(path)
     })
 
     if (otherPaths.size > 0) {
       const loadOtherPaths = () => {
         otherPaths.forEach((path) => {
-          loadIcon(path, false)
+          if (displayIcon) loadIcon(path, false)
           if (displayAppName) loadAppName(path)
         })
       }
@@ -385,7 +387,9 @@ const Connections: React.FC = () => {
     if (processIconIdleCallback.current) cancelIdleCallback(processIconIdleCallback.current)
     if (processAppNameTimer.current) clearTimeout(processAppNameTimer.current)
 
-    processIconTimer.current = setTimeout(processIconQueue, 10)
+    if (displayIcon) {
+      processIconTimer.current = setTimeout(processIconQueue, 10)
+    }
     if (displayAppName) {
       processAppNameTimer.current = setTimeout(processAppNameQueue, 10)
     }
@@ -468,6 +472,7 @@ const Connections: React.FC = () => {
     (i: number, connection: IMihomoConnectionDetail) => {
       const path = connection.metadata.processPath || ''
       const iconUrl = (displayIcon && findProcessMode !== 'off' && iconMap[path]) || ''
+      const shouldDisplayIcon = displayIcon && findProcessMode !== 'off' && Boolean(path)
       const itemKey = i === 0 ? `${connection.id}-${firstItemRefreshTrigger}` : connection.id
       const displayName =
         displayAppName && connection.metadata.processPath
@@ -480,7 +485,7 @@ const Connections: React.FC = () => {
           setIsDetailModalOpen={setIsDetailModalOpen}
           selected={selected}
           iconUrl={iconUrl}
-          displayIcon={displayIcon && findProcessMode !== 'off'}
+          displayIcon={shouldDisplayIcon}
           displayName={displayName}
           close={closeConnection}
           index={i}


### PR DESCRIPTION
## 中文说明

### 改动内容

- 在 Windows 上读取可执行文件的 `FileDescription` / `ProductName`，用于在“连接”页面显示友好的应用名称。
- 将应用名称加载与应用图标加载解耦，关闭图标后仍可显示友好名称。
- 跳过空的进程路径；当 Mihomo 未返回进程信息时，不再显示容易产生误解的通用头像。
- 添加针对 Windows 应用名称读取和路径转义的测试。

### 修改原因

Mihomo 已通过 `find-process-mode` 控制进程查找，并在启用进程匹配时返回 `process` / `processPath`。Clash Party 原本已经可以根据该路径提取 Windows 应用图标，但 `getAppName` 只实现了 macOS 的友好名称读取。因此，Windows 上通常只能显示 `chrome` 之类的可执行文件名，而不是 `Google Chrome`。

此外，原有的应用名称加载依赖“显示图标”开关；关闭图标会意外导致友好名称也不再加载。

本次修改不会另外实现进程查找，也不会改变 Mihomo 原有配置语义：

- `strict`（自动）：由 Mihomo 判断是否需要查找进程。
- `always`（开启）：由 Mihomo 强制为所有连接查找进程。
- `off`（关闭）：不查找进程。

对于 Mihomo 未返回进程信息的 TUN / Fake-IP 连接，界面仍显示其虚拟来源地址，不会猜测所属应用。

### 影响范围

- 当 Mihomo 返回 Windows 可执行文件路径时，“连接”页面可以显示 `Google Chrome` 等友好名称，同时继续复用现有图标提取流程。
- 关闭应用图标后仍可显示应用名称。
- 不影响进程匹配行为、核心配置以及 macOS / Linux 的现有行为。

### 验证

- 修改文件通过 `pnpm exec prettier --check`
- 修改文件通过 `pnpm exec eslint`
- `pnpm run typecheck` 通过
- `pnpm exec vitest run src/main/utils/appName.test.ts`：2 个测试通过
- Windows 安装包已完成构建和人工测试；“连接”页面中的友好应用名称和图标显示正常

仓库当前基线情况：完整 Vitest 测试在 Windows 上有两个与本次修改无关的路径分隔符失败，其他 171 个测试通过；全仓 Prettier 检查还会检测到当前工作区已有的换行符差异，但本次修改的文件均通过检查。

---

## English

### What

- Read Windows executable `FileDescription` / `ProductName` values for friendly application names in the Connections page.
- Load application names independently from application icons.
- Skip empty process paths and avoid rendering a misleading generic avatar when Mihomo did not return process metadata.
- Add focused tests for Windows executable-name lookup and path escaping.

### Why

Mihomo already controls process discovery through `find-process-mode` and returns `process` / `processPath` metadata when matching is enabled. Clash Party already uses that path to extract Windows application icons, but `getAppName` only implemented friendly names for macOS. On Windows, the UI therefore fell back to executable names such as `chrome` instead of `Google Chrome`.

Application-name loading was also coupled to the icon setting, so disabling icons unintentionally prevented friendly names from loading.

This change deliberately does not implement a second process-discovery mechanism. The existing Mihomo semantics remain unchanged:

- `strict`: Mihomo decides when process matching is required.
- `always`: Mihomo forces process matching for all connections.
- `off`: no process matching is performed.

TUN / Fake-IP connections without Mihomo process metadata remain attributed to their virtual source address rather than being guessed by the UI.

### Impact

- Windows connections with a Mihomo-provided executable path can display friendly names such as `Google Chrome` while continuing to use the existing executable icon pipeline.
- Users may show application names with icons disabled.
- Process-matching behavior, core configuration, and macOS / Linux behavior are unchanged.

### Checks

- `pnpm exec prettier --check` on all changed files
- `pnpm exec eslint` on all changed files
- `pnpm run typecheck`
- `pnpm exec vitest run src/main/utils/appName.test.ts` (2 passed)
- Windows package built and tested manually; friendly application names and icons confirmed in the Connections page

Known repository baseline: the full Vitest run has two unrelated Windows path-separator failures; the other 171 tests pass. The full-repository Prettier check also detects existing checkout-wide line-ending differences, while all changed files pass Prettier.
