### PR TITLE
fix: prevent command injection in convertMrsRuleset

### DIFF
--- a/src/main/config/profile.ts
+++ b/src/main/config/profile.ts
@@ -1,6 +1,6 @@
 import { access, readFile, rm, unlink } from 'fs/promises'
 import { constants, existsSync } from 'fs'
-import { exec, execFile } from 'child_process'
+import { execFile } from 'child_process'
 import { isAbsolute, join, relative, resolve } from 'path'
 import { promisify } from 'util'
 import { randomBytes } from 'crypto'
@@ -663,8 +663,13 @@ export async function setFileStr(path: string, content: string): Promise<void> {
   }
 }
 
+const MRS_RULESET_BEHAVIORS = ['domain', 'ipcidr', 'classical'] as const
+
 export async function convertMrsRuleset(filePath: string, behavior: string): Promise<string> {
-  const execAsync = promisify(exec)
+  // behavior 来自订阅下发的 rule-providers，属于不可信输入，只接受内核支持的固定取值
+  if (!(MRS_RULESET_BEHAVIORS as readonly string[]).includes(behavior)) {
+    throw new Error(`Unsupported ruleset behavior: ${behavior}`)
+  }
 
   const { core = 'mihomo' } = await getAppConfig()
   const corePath = mihomoCorePath(core)
@@ -683,7 +688,8 @@ export async function convertMrsRuleset(filePath: string, behavior: string): Pro
   try {
     // 使用 mihomo convert-ruleset 命令转换 MRS 文件为 text 格式
     // 命令格式：mihomo convert-ruleset <behavior> <format> <source>
-    await execAsync(`"${corePath}" convert-ruleset ${behavior} mrs "${fullPath}" "${tempFilePath}"`)
+    // 用 execFile 传参数数组，避免 behavior / 路径经过 shell 解析导致命令注入
+    await execFilePromise(corePath, ['convert-ruleset', behavior, 'mrs', fullPath, tempFilePath])
     const content = await readFile(tempFilePath, 'utf-8')
     await unlink(tempFilePath)
 


### PR DESCRIPTION
fix: prevent command injection in convertMrsRuleset

convertMrsRuleset built a shell command string from `behavior` and the
resolved ruleset path and ran it through `exec`. `behavior` comes from
the runtime config's `rule-providers`, which originates from the user's
subscription YAML and is therefore untrusted input.

A malicious or compromised subscription can set a behavior such as
`domain & <command> &`; opening that ruleset in the resource viewer then
executes arbitrary commands with the app's privileges. The quoted paths
are also breakable on Windows via an embedded double quote.

Switch to `execFile` with an argument array so nothing is parsed by a
shell, and reject any behavior outside the set the core supports.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
Verified on Windows 11: `pnpm run review` (prettier + eslint + tsc) and `pnpm run test` (176 tests) pass, and `electron-vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
