### PR TITLE
chore: add .gitattributes to pin LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,36 @@
+# 仓库统一使用 LF。
+#
+# 没有这个文件时，Windows 上 git 的默认 core.autocrlf=true 会把源码检出成 CRLF，
+# 而 prettier 默认要求 LF（.prettierrc.yaml 未覆盖 endOfLine），结果是：
+#   - `pnpm run format:check` / `pnpm run review` 把几乎每个文件都报成有差异
+#   - .githooks/pre-commit 因此必定失败，Windows 贡献者无法正常提交
+* text=auto eol=lf
+
+# Shell 脚本必须是 LF，否则在 Linux/macOS 上会因 \r 而无法执行
+*.sh text eol=lf
+*.install text eol=lf
+*.desktop text eol=lf
+
+# Windows 批处理需要 CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# 二进制文件不做任何行尾转换
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.icns binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary
+*.zip binary
+*.gz binary
+*.7z binary
+*.exe binary
+*.dll binary
+*.dylib binary
+*.so binary
+*.node binary


### PR DESCRIPTION
chore: add .gitattributes to pin LF line endings

The repository has no .gitattributes. On Windows, Git for Windows
defaults to core.autocrlf=true, so a fresh clone checks every source
file out with CRLF. Prettier defaults to endOfLine: "lf" and
.prettierrc.yaml does not override it, so on Windows:

  - `pnpm run format:check` reports essentially every file as different
  - `pnpm run review` therefore always fails
  - .githooks/pre-commit fails for the same reason, so a Windows
    contributor cannot produce a passing commit at all

Committing `* text=auto eol=lf` makes checkouts use LF on every
platform and fixes all three. Every blob already stored in the
repository uses LF, so no renormalization commit is needed and this
change produces no diff in file contents.

Shell scripts and the AUR .install/.desktop files are pinned to LF
explicitly (a stray CR breaks them on Linux/macOS), .bat/.cmd are
pinned to CRLF, and binary assets are excluded from conversion.

Verified on Windows 11: before this change `pnpm run format:check`
lists 300+ files; after a clean checkout with this file it passes,
as do lint, typecheck and the full vitest suite.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
Verified on Windows 11: `pnpm run review` (prettier + eslint + tsc) and `pnpm run test` (176 tests) pass, and `electron-vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
