### PR TITLE
fix: core process identification, IPC socket cleanup and group refresh

### DIFF
--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -647,16 +647,9 @@ function setupCoreListeners(
 
     // TUN 权限错误
     if (str.includes('configure tun interface: operation not permitted')) {
-      // 必须等配置真正落盘、内存缓存换新后再通知 UI，否则界面读回的还是 tun.enable=true 的旧缓存。
-      // 这里不能 await：patchControledMihomoConfig 内部可能触发 restartCore，会把本次启动失败的上报拖住。
       patchControledMihomoConfig({ tun: { enable: false } })
-        .catch((error) => {
-          managerLogger.error('Failed to disable TUN after permission error', error)
-        })
-        .finally(() => {
-          mainWindow?.webContents.send('controledMihomoConfigUpdated')
-          ipcMain.emit('updateTrayMenu')
-        })
+      mainWindow?.webContents.send('controledMihomoConfigUpdated')
+      ipcMain.emit('updateTrayMenu')
       rejectStartup(i18next.t('tun.error.tunPermissionDenied'))
       return
     }
@@ -693,27 +686,30 @@ function setupCoreListeners(
       (process.platform === 'win32' && str.includes('RESTful API pipe listening at'))
 
     if (isApiReady) {
+      // API 就绪即完成启动收尾（与 post-up 模式一致）。此前要等内核打出
+      // 'start initial compatible provider default' 才发 groupsUpdated，该行出现得很晚、
+      // 甚至可能不出现，导致切换订阅后代理组只能靠 30 秒轮询才刷新。
       resolveStartup([
-        new Promise((innerResolve) => {
-          proc.stdout?.on('data', async (innerData) => {
-            if (
-              innerData
-                .toString()
-                .toLowerCase()
-                .includes('start initial compatible provider default')
-            ) {
-              completeCoreStartup()
-                .then(() => innerResolve())
-                .catch((error) => {
-                  managerLogger.warn('Failed to complete core startup', error)
-                  innerResolve()
-                })
-            }
+        startMihomoApiStreams()
+          .then(() => completeCoreStartup())
+          .catch((error) => {
+            managerLogger.warn('Failed to complete core startup', error)
           })
-        })
       ])
 
-      await startMihomoApiStreams()
+      // 内核装载完 provider 后再补发一次：API 端口先于代理组装载就绪，
+      // 上面那次刷新可能取到尚未更新的代理组。
+      const notifyProvidersReady = (innerData: Buffer): void => {
+        if (
+          !innerData.toString().toLowerCase().includes('start initial compatible provider default')
+        ) {
+          return
+        }
+        proc.stdout?.off('data', notifyProvidersReady)
+        mainWindow?.webContents.send('groupsUpdated')
+        mainWindow?.webContents.send('rulesUpdated')
+      }
+      proc.stdout?.on('data', notifyProvidersReady)
     }
   })
 

--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -401,7 +401,9 @@ export const getMihomoIpcPath = (): string => {
       : `\\\\.\\pipe\\MihomoParty\\mihomo-user-${sessionId}-${processId}`
   }
 
-  const uid = process.getuid?.() || 'unknown'
+  // 注意用 ?? 而非 ||：root 的 uid 是 0，用 || 会被判为假值而退化成 'unknown'，
+  // 导致以 root 运行时的 socket 路径和清理逻辑对不上。
+  const uid = process.getuid?.() ?? 'unknown'
   const processId = process.pid
   return `/tmp/mihomo-party-${uid}-${processId}.sock`
 }

--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -401,9 +401,7 @@ export const getMihomoIpcPath = (): string => {
       : `\\\\.\\pipe\\MihomoParty\\mihomo-user-${sessionId}-${processId}`
   }
 
-  // 注意用 ?? 而非 ||：root 的 uid 是 0，用 || 会被判为假值而退化成 'unknown'，
-  // 导致以 root 运行时的 socket 路径和清理逻辑对不上。
-  const uid = process.getuid?.() ?? 'unknown'
+  const uid = process.getuid?.() || 'unknown'
   const processId = process.pid
   return `/tmp/mihomo-party-${uid}-${processId}.sock`
 }
@@ -649,9 +647,16 @@ function setupCoreListeners(
 
     // TUN 权限错误
     if (str.includes('configure tun interface: operation not permitted')) {
+      // 必须等配置真正落盘、内存缓存换新后再通知 UI，否则界面读回的还是 tun.enable=true 的旧缓存。
+      // 这里不能 await：patchControledMihomoConfig 内部可能触发 restartCore，会把本次启动失败的上报拖住。
       patchControledMihomoConfig({ tun: { enable: false } })
-      mainWindow?.webContents.send('controledMihomoConfigUpdated')
-      ipcMain.emit('updateTrayMenu')
+        .catch((error) => {
+          managerLogger.error('Failed to disable TUN after permission error', error)
+        })
+        .finally(() => {
+          mainWindow?.webContents.send('controledMihomoConfigUpdated')
+          ipcMain.emit('updateTrayMenu')
+        })
       rejectStartup(i18next.t('tun.error.tunPermissionDenied'))
       return
     }

--- a/src/main/core/process.ts
+++ b/src/main/core/process.ts
@@ -1,8 +1,8 @@
 import { exec, execFile } from 'child_process'
 import { promisify } from 'util'
-import { readdir, rm } from 'fs/promises'
+import { rm } from 'fs/promises'
 import { existsSync } from 'fs'
-import { join } from 'path'
+import path from 'path'
 import { managerLogger } from '../utils/logger'
 import { getAxios } from './mihomoApi'
 
@@ -12,7 +12,6 @@ const execFilePromise = promisify(execFile)
 // 常量
 const CORE_READY_MAX_RETRIES = 30
 const CORE_READY_RETRY_INTERVAL_MS = 100
-const CORE_PROCESS_NAMES = ['mihomo', 'mihomo-alpha', 'mihomo-smart'] as const
 
 export async function cleanupSocketFile(): Promise<void> {
   if (process.platform === 'win32') {
@@ -104,66 +103,33 @@ async function terminateProcess(pid: number): Promise<void> {
 async function fallbackTextParsing(stdout: string): Promise<void> {
   const lines = stdout.split('\n').filter((line) => line.includes('mihomo'))
   for (const line of lines) {
-    // 旧实现取行内第一个数字就当 PID 杀，PowerShell 输出格式一变就可能误杀无关进程。
-    // 这里只认 Id 字段，并且杀之前必须确认目标确实是内核进程。
-    const match = line.match(/"?\bId"?\s*[:=]\s*"?(\d+)/i)
-    if (!match) continue
-
-    const pid = parseInt(match[1], 10)
-    if (!Number.isInteger(pid) || pid <= 0 || pid === process.pid) continue
-    if (!(await verifyProcessOwner(pid, CORE_PROCESS_NAMES))) {
-      managerLogger.info(`PID ${pid} is not a known mihomo process, skipping terminate`)
-      continue
+    const match = line.match(/(\d+)/)
+    if (match) {
+      const pid = parseInt(match[1])
+      if (pid !== process.pid) {
+        await terminateProcess(pid)
+      }
     }
-
-    await terminateProcess(pid)
-  }
-}
-
-// 与 getMihomoIpcPath() 生成的 `/tmp/mihomo-party-<uid>-<pid>.sock` 保持一致。
-const UNIX_SOCKET_DIR = '/tmp'
-const UNIX_SOCKET_PATTERN = /^mihomo-party-(\d+|unknown)-(\d+)\.sock$/
-const LEGACY_UNIX_SOCKETS = ['/tmp/mihomo-party.sock', '/tmp/mihomo-party-admin.sock']
-
-async function removeSocketFile(socketPath: string): Promise<void> {
-  try {
-    if (existsSync(socketPath)) {
-      await rm(socketPath)
-      managerLogger.info(`Cleaned up socket file: ${socketPath}`)
-    }
-  } catch (error) {
-    managerLogger.warn(`Failed to cleanup socket file ${socketPath}:`, error)
-  }
-}
-
-function isPidAlive(pid: number): boolean {
-  if (!Number.isInteger(pid) || pid <= 0) return false
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch (error) {
-    // EPERM 说明进程存在但不属于当前用户，不能当作已退出
-    return (error as NodeJS.ErrnoException)?.code === 'EPERM'
   }
 }
 
 export async function cleanupUnixSockets(): Promise<void> {
   try {
-    for (const socketPath of LEGACY_UNIX_SOCKETS) {
-      await removeSocketFile(socketPath)
-    }
+    const socketPaths = [
+      '/tmp/mihomo-party.sock',
+      '/tmp/mihomo-party-admin.sock',
+      `/tmp/mihomo-party-${process.getuid?.() || 'user'}.sock`
+    ]
 
-    // 旧实现只删几个固定名字，和实际带 uid/pid 的 socket 名对不上，
-    // 结果 /tmp 下的 socket 会一直累积。这里按命名规则回收自己的和已退出进程的残留。
-    const entries = await readdir(UNIX_SOCKET_DIR).catch(() => [] as string[])
-    for (const entry of entries) {
-      const match = UNIX_SOCKET_PATTERN.exec(entry)
-      if (!match) continue
-
-      const pid = parseInt(match[2], 10)
-      if (pid !== process.pid && isPidAlive(pid)) continue
-
-      await removeSocketFile(join(UNIX_SOCKET_DIR, entry))
+    for (const socketPath of socketPaths) {
+      try {
+        if (existsSync(socketPath)) {
+          await rm(socketPath)
+          managerLogger.info(`Cleaned up socket file: ${socketPath}`)
+        }
+      } catch (error) {
+        managerLogger.warn(`Failed to cleanup socket file ${socketPath}:`, error)
+      }
     }
   } catch (error) {
     managerLogger.error('Unix socket cleanup failed:', error)
@@ -240,7 +206,8 @@ export async function verifyProcessOwner(
       processName = stdout.trim().split(/\r?\n/, 1)[0] || ''
     }
 
-    const normalizedName = normalizeProcessName(processName)
+    // macOS/BSD 的 `ps -o comm=` 输出的是可执行文件全路径，取 basename 后短名与全路径都能匹配
+    const normalizedName = normalizeProcessName(path.basename(processName))
     return expectedNames.some((name) => normalizeProcessName(name) === normalizedName)
   } catch {
     return false

--- a/src/main/core/process.ts
+++ b/src/main/core/process.ts
@@ -1,7 +1,8 @@
 import { exec, execFile } from 'child_process'
 import { promisify } from 'util'
-import { rm } from 'fs/promises'
+import { readdir, rm } from 'fs/promises'
 import { existsSync } from 'fs'
+import { join } from 'path'
 import { managerLogger } from '../utils/logger'
 import { getAxios } from './mihomoApi'
 
@@ -11,6 +12,7 @@ const execFilePromise = promisify(execFile)
 // 常量
 const CORE_READY_MAX_RETRIES = 30
 const CORE_READY_RETRY_INTERVAL_MS = 100
+const CORE_PROCESS_NAMES = ['mihomo', 'mihomo-alpha', 'mihomo-smart'] as const
 
 export async function cleanupSocketFile(): Promise<void> {
   if (process.platform === 'win32') {
@@ -102,33 +104,66 @@ async function terminateProcess(pid: number): Promise<void> {
 async function fallbackTextParsing(stdout: string): Promise<void> {
   const lines = stdout.split('\n').filter((line) => line.includes('mihomo'))
   for (const line of lines) {
-    const match = line.match(/(\d+)/)
-    if (match) {
-      const pid = parseInt(match[1])
-      if (pid !== process.pid) {
-        await terminateProcess(pid)
-      }
+    // 旧实现取行内第一个数字就当 PID 杀，PowerShell 输出格式一变就可能误杀无关进程。
+    // 这里只认 Id 字段，并且杀之前必须确认目标确实是内核进程。
+    const match = line.match(/"?\bId"?\s*[:=]\s*"?(\d+)/i)
+    if (!match) continue
+
+    const pid = parseInt(match[1], 10)
+    if (!Number.isInteger(pid) || pid <= 0 || pid === process.pid) continue
+    if (!(await verifyProcessOwner(pid, CORE_PROCESS_NAMES))) {
+      managerLogger.info(`PID ${pid} is not a known mihomo process, skipping terminate`)
+      continue
     }
+
+    await terminateProcess(pid)
+  }
+}
+
+// 与 getMihomoIpcPath() 生成的 `/tmp/mihomo-party-<uid>-<pid>.sock` 保持一致。
+const UNIX_SOCKET_DIR = '/tmp'
+const UNIX_SOCKET_PATTERN = /^mihomo-party-(\d+|unknown)-(\d+)\.sock$/
+const LEGACY_UNIX_SOCKETS = ['/tmp/mihomo-party.sock', '/tmp/mihomo-party-admin.sock']
+
+async function removeSocketFile(socketPath: string): Promise<void> {
+  try {
+    if (existsSync(socketPath)) {
+      await rm(socketPath)
+      managerLogger.info(`Cleaned up socket file: ${socketPath}`)
+    }
+  } catch (error) {
+    managerLogger.warn(`Failed to cleanup socket file ${socketPath}:`, error)
+  }
+}
+
+function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    // EPERM 说明进程存在但不属于当前用户，不能当作已退出
+    return (error as NodeJS.ErrnoException)?.code === 'EPERM'
   }
 }
 
 export async function cleanupUnixSockets(): Promise<void> {
   try {
-    const socketPaths = [
-      '/tmp/mihomo-party.sock',
-      '/tmp/mihomo-party-admin.sock',
-      `/tmp/mihomo-party-${process.getuid?.() || 'user'}.sock`
-    ]
+    for (const socketPath of LEGACY_UNIX_SOCKETS) {
+      await removeSocketFile(socketPath)
+    }
 
-    for (const socketPath of socketPaths) {
-      try {
-        if (existsSync(socketPath)) {
-          await rm(socketPath)
-          managerLogger.info(`Cleaned up socket file: ${socketPath}`)
-        }
-      } catch (error) {
-        managerLogger.warn(`Failed to cleanup socket file ${socketPath}:`, error)
-      }
+    // 旧实现只删几个固定名字，和实际带 uid/pid 的 socket 名对不上，
+    // 结果 /tmp 下的 socket 会一直累积。这里按命名规则回收自己的和已退出进程的残留。
+    const entries = await readdir(UNIX_SOCKET_DIR).catch(() => [] as string[])
+    for (const entry of entries) {
+      const match = UNIX_SOCKET_PATTERN.exec(entry)
+      if (!match) continue
+
+      const pid = parseInt(match[2], 10)
+      if (pid !== process.pid && isPidAlive(pid)) continue
+
+      await removeSocketFile(join(UNIX_SOCKET_DIR, entry))
     }
   } catch (error) {
     managerLogger.error('Unix socket cleanup failed:', error)


### PR DESCRIPTION
fix: correct IPC socket path and cleanup for the core process

Three related defects in how the core's IPC socket path is derived and
how leftover sockets and processes are cleaned up.

1. getMihomoIpcPath() used `process.getuid?.() || 'unknown'`. root's uid
   is 0, which is falsy, so running as root produced
   /tmp/mihomo-party-unknown-<pid>.sock instead of
   /tmp/mihomo-party-0-<pid>.sock. Use `??` so only a missing getuid
   falls back.

2. cleanupUnixSockets() only removed three fixed names
   (/tmp/mihomo-party.sock, -admin.sock and a uid-only variant). None of
   them is a path getMihomoIpcPath() ever generates, because the real
   name embeds both uid and pid. The sockets the app actually creates
   were therefore never cleaned up and accumulated in /tmp for the life
   of the machine. Match the real naming scheme, and only unlink entries
   belonging to this process or to a pid that is no longer alive. EPERM
   from kill(pid, 0) is treated as "alive" so a socket owned by another
   user's live core is left alone.

3. fallbackTextParsing() took the first number on any line containing
   "mihomo" and sent SIGTERM to it. That line comes from PowerShell
   output whose shape is not guaranteed once ConvertTo-Json parsing has
   already failed, so an unrelated process could be terminated. Parse
   only an explicit Id field and confirm via verifyProcessOwner() that
   the target really is a core process before terminating it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

fix: identify the core process correctly on macOS

verifyProcessOwner compares the output of `ps -p <pid> -o comm=` against
the bare core names. On Linux `comm` is the short name, but on macOS the
`comm` keyword prints argv[0] - the full executable path - so for a core
spawned from an absolute path the comparison can never match and the
function returns false for a genuine mihomo process.

The practical effect is on the lightweight-mode path. quitWithoutCore
records the detached core's pid, and on the next launch stopPidFileCore is
the only thing that reaps it on macOS. It refuses to signal the pid it
cannot verify, then removes the pid file anyway, so the orphaned core is
unreachable from then on - and it still holds the mixed port and TUN while
the new core starts beside it. Each lightweight-mode cycle can leave
another one behind.

Compare the basename so both the short name and a full path match.

Also await patchControledMihomoConfig on the TUN-permission-denied path
before notifying the renderer, so the UI cannot read the old value back.

fix: refresh proxy groups as soon as the core API is ready

In the default log startup mode, completeCoreStartup - which sends
groupsUpdated and rulesUpdated - was invoked from a nested stdout handler
that waited for one specific core log line ("start initial compatible
provider default"). When that line does not appear, because the profile
has no compatible provider or the log level is lower, the events were
never sent at all. The renderer only revalidates its groups on that event,
otherwise falling back to a 30 second poll while keepPreviousData keeps
the previous subscription's groups on screen. Switching profiles therefore
appeared to take ten or more seconds, or to have selected the wrong one.

Send the events once the API is ready, and keep a one-shot listener for
the provider log line to send them again afterwards - the RESTful API
starts listening before ApplyConfig, so the first refresh can still race
the group swap.

Refs #1198
Refs #1169

A renderer-side fallback (re-sending after changeCurrentProfile, and the
30s poll interval) is not part of this change, so a narrow window remains.

---
Verified on Windows 11: `pnpm run review` (prettier + eslint + tsc) and `pnpm run test` (176 tests) pass, and `electron-vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
