### PR TITLE
fix: do not let a failed window creation surface as an uncaught exception

### DIFF
--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -399,11 +399,14 @@ export function showMainWindow(): void {
     return
   }
 
-  void createWindow().then(() => {
-    clearQuitTimeout()
-    mainWindow?.show()
-    mainWindow?.focusOnWebView()
-  })
+  // createWindow 重试耗尽后会 throw，缺 catch 会变成主进程未捕获异常弹窗。
+  void createWindow()
+    .then(() => {
+      clearQuitTimeout()
+      mainWindow?.show()
+      mainWindow?.focusOnWebView()
+    })
+    .catch((error) => mainWindowLogger.error('Failed to show main window', error))
 }
 
 export function closeMainWindow(): void {


### PR DESCRIPTION
`createWindow()` throws once its retries are exhausted. The call site in
`showMainWindow()` only attached a `then`, so that rejection became an unhandled
promise rejection and the user got a raw main-process error dialog instead of a
log line.

Attach a `catch` and log it.

---

**This PR has been reduced to just that fix.** It previously also carried
main-process startup ordering and a TUN `route-exclude-address` change; both were
reworked on top of the current `smart_core` and opened separately, so keeping them
here would have meant two pull requests touching the same lines:

- startup ordering → #2120
- `route-exclude-address` → #2122

Note #2122 takes a different approach to the TUN option than this branch used to:
it drops the app-managed empty list before merging, so the profile's own value
survives, rather than merging both sources and de-duplicating. That seemed like
the smaller and less surprising behaviour, but say the word if you would rather
have the union.
