### PR TITLE
fix: remove read-modify-write races and validate override downloads

### DIFF
--- a/src/main/config/controledMihomo.ts
+++ b/src/main/config/controledMihomo.ts
@@ -67,6 +67,12 @@ export async function patchControledMihomoConfig(patch: Partial<IMihomoConfig>):
       JSON.stringify(controledMihomoConfig || cloneDefaultControledMihomoConfig())
     ) as Partial<IMihomoConfig>
     const nextPatch = JSON.parse(JSON.stringify(patch)) as Partial<IMihomoConfig>
+    // JSON 序列化会丢掉值为 undefined 的键，而这里 undefined 表示「删除该键」，需要补回
+    for (const key of Object.keys(patch)) {
+      if ((patch as Record<string, unknown>)[key] === undefined) {
+        ;(nextPatch as Record<string, unknown>)[key] = undefined
+      }
+    }
     let restoreDnsState = false
 
     // 当模式从 direct 切换到 rule/global 时，恢复之前保存的 DNS 状态

--- a/src/main/config/override.ts
+++ b/src/main/config/override.ts
@@ -28,40 +28,63 @@ export async function setOverrideConfig(config: IOverrideConfig): Promise<void> 
   })
 }
 
+// 在写队列内部重新读取后再修改，避免「队列外读快照 → 长时间 await → 整体写回」吞掉并发修改
+export async function updateOverrideConfig(
+  updater: (config: IOverrideConfig) => IOverrideConfig
+): Promise<void> {
+  await overrideConfigWriteQueue.run(async () => {
+    const data = await readFile(overrideConfigPath(), 'utf-8')
+    const currentConfig = (parse(data) || { items: [] }) as IOverrideConfig
+    if (typeof currentConfig !== 'object') {
+      throw new Error('Override config is invalid')
+    }
+    if (!Array.isArray(currentConfig.items)) currentConfig.items = []
+    const nextConfig = updater(JSON.parse(JSON.stringify(currentConfig)) as IOverrideConfig)
+    await atomicWriteFile(overrideConfigPath(), stringify(nextConfig), { encoding: 'utf8' })
+    overrideConfig = nextConfig
+  })
+}
+
 export async function getOverrideItem(id: string | undefined): Promise<IOverrideItem | undefined> {
   const { items } = await getOverrideConfig()
   return items.find((item) => item.id === id)
 }
 
 export async function updateOverrideItem(item: IOverrideItem): Promise<void> {
-  const config = await getOverrideConfig()
-  const index = config.items.findIndex((i) => i.id === item.id)
-  if (index === -1) {
-    throw new Error('Override not found')
-  }
-  config.items[index] = item
-  await setOverrideConfig(config)
+  await updateOverrideConfig((config) => {
+    const index = config.items.findIndex((i) => i.id === item.id)
+    if (index === -1) {
+      throw new Error('Override not found')
+    }
+    config.items[index] = item
+    return config
+  })
 }
 
 export async function addOverrideItem(item: Partial<IOverrideItem>): Promise<void> {
-  const config = await getOverrideConfig()
+  // 先完成下载/落盘（可能耗时数秒），再进入写队列做读-改-写
   const newItem = await createOverride(item)
-  if (await getOverrideItem(item.id)) {
-    await updateOverrideItem(newItem)
-  } else {
-    config.items.push(newItem)
-    await setOverrideConfig(config)
-  }
+  await updateOverrideConfig((config) => {
+    const index = config.items.findIndex((i) => i.id === newItem.id)
+    if (index === -1) {
+      config.items.push(newItem)
+    } else {
+      config.items[index] = newItem
+    }
+    return config
+  })
 }
 
 export async function removeOverrideItem(id: string): Promise<void> {
-  const config = await getOverrideConfig()
-  const item = await getOverrideItem(id)
-  if (!item) return
-  config.items = config.items?.filter((i) => i.id !== id)
-  await setOverrideConfig(config)
-  if (existsSync(overridePath(id, item.ext))) {
-    await rm(overridePath(id, item.ext))
+  let removedItem: IOverrideItem | undefined
+  await updateOverrideConfig((config) => {
+    removedItem = config.items?.find((i) => i.id === id)
+    config.items = config.items?.filter((i) => i.id !== id)
+    return config
+  })
+  if (!removedItem) return
+  if (existsSync(overridePath(id, removedItem.ext))) {
+    await rm(overridePath(id, removedItem.ext))
   }
 }
 
@@ -81,14 +104,19 @@ export async function createOverride(item: Partial<IOverrideItem>): Promise<IOve
       const { 'mixed-port': mixedPort = DEFAULT_MIHOMO_PORTS.mixed } =
         await getControledMihomoConfig()
       if (!item.url) throw new Error('Empty URL')
+      // 混合端口为 0 表示代理端口已关闭，此时必须直连，否则会拼出 127.0.0.1:0 的代理
+      const proxy =
+        mixedPort === 0
+          ? (false as const)
+          : { protocol: 'http' as const, host: '127.0.0.1', port: mixedPort }
       const res = await chromeRequest.get(item.url, {
-        proxy: {
-          protocol: 'http',
-          host: '127.0.0.1',
-          port: mixedPort
-        },
+        proxy,
         responseType: 'text'
       })
+      // chromeRequest 对任何状态码都会 resolve，不校验会把 404 错误页当成覆写内容写入
+      if (res.status < 200 || res.status >= 300) {
+        throw new Error(`Override download failed: status ${res.status}`)
+      }
       const data = res.data as string
       await setOverride(id, newItem.ext, data)
       break


### PR DESCRIPTION
fix: remove read-modify-write races and validate override downloads

- addOverrideItem read the config outside the write queue, then awaited
  createOverride - which for a remote override downloads over the network
  and can take seconds - and finally wrote the stale snapshot back in
  full. Any change made meanwhile was lost. updateOverrideItem and
  removeOverrideItem had the same shape. Move the read inside the queue
  and re-read from disk there, matching what profile.ts already does.

- The remote override download never checked the HTTP status, so a 404 or
  502 error page was written out as the override body. applyOverrides then
  parses it with no try, and the failure surfaces as a core restart error.

- The download built its proxy from the mixed port with a destructuring
  default, so with the port turned off (0) it went to 127.0.0.1:0.

- patchControledMihomoConfig ran the patch through JSON.parse(stringify),
  which drops keys whose value is undefined. The startup migration uses
  exactly that to delete obsolete keys such as external-controller-unix,
  so those deletions never happened - the keys stayed in mihomo.yaml and
  the migration re-ran its full rewrite, config regeneration and Gist
  upload on every launch. Restore top-level undefined keys after the
  round-trip so yaml.stringify can drop them for real.

---
Verified on Windows 11: `pnpm run review` (prettier + eslint + tsc) and `pnpm run test` (176 tests) pass, and `electron-vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
