### PR TITLE
fix: repair drag-and-drop on the override page

### DIFF
--- a/src/renderer/src/pages/override.tsx
+++ b/src/renderer/src/pages/override.tsx
@@ -70,8 +70,11 @@ const Override: React.FC = () => {
         const newOrder = sortedItems.slice()
         const activeIndex = newOrder.findIndex((item) => item.id === active.id)
         const overIndex = newOrder.findIndex((item) => item.id === over.id)
-        newOrder.splice(activeIndex, 1)
-        newOrder.splice(overIndex, 0, items[activeIndex])
+        if (activeIndex === -1 || overIndex === -1) return
+        // 必须插回从 newOrder 里移除的那一项：items 与 sortedItems 会在写入失败时分叉，
+        // 用 items[activeIndex] 会插入错误的元素，导致一项重复、一项丢失
+        const [movedItem] = newOrder.splice(activeIndex, 1)
+        newOrder.splice(overIndex, 0, movedItem)
         setSortedItems(newOrder)
         await setOverrideConfig({ items: newOrder })
       }
@@ -103,25 +106,31 @@ const Override: React.FC = () => {
     const handleDrop = async (event: DragEvent): Promise<void> => {
       event.preventDefault()
       event.stopPropagation()
-      if (event.dataTransfer?.files) {
-        const file = event.dataTransfer.files[0]
-        if (file.name.endsWith('.js') || file.name.endsWith('.yaml')) {
-          const content = await readTextFile((file as File & { path: string }).path)
-          try {
+      try {
+        if (event.dataTransfer?.files) {
+          const file = event.dataTransfer.files[0]
+          // 拖入选中文字或链接时 files 长度为 0（FileList 本身仍是真值），file 可能为 undefined
+          const name = file?.name.toLowerCase() ?? ''
+          if (name.endsWith('.js') || name.endsWith('.yaml')) {
+            // Electron 32 起已移除 File 上的非标准 path 属性，只能通过 webUtils 拿真实路径
+            const path = window.api.webUtils.getPathForFile(file)
+            const content = await readTextFile(path)
             await addOverrideItemRef.current({
               name: file.name,
               type: 'local',
               file: content,
-              ext: file.name.endsWith('.js') ? 'js' : 'yaml'
+              ext: name.endsWith('.js') ? 'js' : 'yaml'
             })
-          } finally {
-            setFileOver(false)
+          } else if (file) {
+            toast.warning(tRef.current('override.unsupportedFileType'))
           }
-        } else {
-          toast.warning(tRef.current('override.unsupportedFileType'))
         }
+      } catch (e) {
+        toast.error(String(e))
+      } finally {
+        // 无论成功失败都要复位，否则页面会一直卡在 blur-sm 模糊态
+        setFileOver(false)
       }
-      setFileOver(false)
     }
 
     element.addEventListener('dragover', handleDragOver)


### PR DESCRIPTION
fix: repair drag-and-drop on the override page

- Dropping a file read `(file as File & { path: string }).path`. Electron
  removed File.path, so the value is undefined and readTextFile always
  failed. Use webUtils.getPathForFile, which preload already exposes and
  which profiles.tsx already uses for the same purpose.

- Reordering computed indices against the sorted copy but spliced in
  `items[activeIndex]` - an element from the unsorted array. Whenever the
  two orders differ this duplicated one entry and dropped another. Splice
  out and reinsert the same element, as profiles.tsx does, and bail out if
  either index is -1.

- The drop handler read `file.name` without checking that the FileList was
  non-empty, so dropping selected text threw a TypeError. The throw also
  skipped the setFileOver(false) reset, leaving the whole page stuck
  behind a blur. Guard the access and reset the flag in a finally block.

---
Verified on Windows 11: `pnpm run review` (prettier + eslint + tsc) and `pnpm run test` (176 tests) pass, and `electron-vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
