### PR TITLE
fix: correct sniffer ports, delay-test deps, debouncing and edge cases

### DIFF
--- a/src/renderer/src/components/settings/mihomo-config.tsx
+++ b/src/renderer/src/components/settings/mihomo-config.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useMemo, useRef, useState } from 'react'
 import { toast } from '@renderer/components/base/toast'
 import { Button, Input, Select, SelectItem, Switch, Tooltip } from '@heroui/react'
 import { useAppConfig } from '@renderer/hooks/use-app-config'
@@ -59,13 +59,24 @@ const MihomoConfig: React.FC = () => {
       profileId
     }))
   )
-  const setUrlDebounce = debounce((v: string) => {
-    patchAppConfig({ delayTestUrl: v })
-  }, 500)
   const [ua, setUa] = useState(userAgent)
-  const setUaDebounce = debounce((v: string) => {
-    patchAppConfig({ userAgent: v })
-  }, 500)
+  // 防抖实例必须跨渲染复用，否则每次按键都会拿到新实例、清不掉上一次的定时器
+  const patchAppConfigRef = useRef(patchAppConfig)
+  patchAppConfigRef.current = patchAppConfig
+  const setUrlDebounce = useMemo(
+    () =>
+      debounce((v: string) => {
+        patchAppConfigRef.current({ delayTestUrl: v })
+      }, 500),
+    []
+  )
+  const setUaDebounce = useMemo(
+    () =>
+      debounce((v: string) => {
+        patchAppConfigRef.current({ userAgent: v })
+      }, 500),
+    []
+  )
   const [isGeneratingGistAgeKey, setIsGeneratingGistAgeKey] = useState(false)
   const [isExportingGistAgeKey, setIsExportingGistAgeKey] = useState(false)
   const handleGenerateGistAgeKeyPair = async (): Promise<void> => {

--- a/src/renderer/src/components/settings/substore-config.tsx
+++ b/src/renderer/src/components/settings/substore-config.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useMemo, useRef, useState } from 'react'
 import SettingCard from '@renderer/components/base/base-setting-card'
 import { toast } from '@renderer/components/base/toast'
 import SettingItem from '@renderer/components/base/base-setting-item'
@@ -30,9 +30,16 @@ const SubStoreConfig: React.FC = () => {
   } = appConfig || {}
 
   const [customSubStoreUrlValue, setCustomSubStoreUrlValue] = useState(customSubStoreUrl)
-  const setCustomSubStoreUrl = debounce(async (v: string) => {
-    await patchAppConfig({ customSubStoreUrl: v })
-  }, 500)
+  // 防抖实例必须跨渲染复用，否则每次按键都会拿到新实例、清不掉上一次的定时器
+  const patchAppConfigRef = useRef(patchAppConfig)
+  patchAppConfigRef.current = patchAppConfig
+  const setCustomSubStoreUrl = useMemo(
+    () =>
+      debounce((v: string) => {
+        void patchAppConfigRef.current({ customSubStoreUrl: v })
+      }, 500),
+    []
+  )
   const [subStoreBackendSyncCronValue, setSubStoreBackendSyncCronValue] =
     useState(subStoreBackendSyncCron)
   const [subStoreBackendDownloadCronValue, setSubStoreBackendDownloadCronValue] = useState(

--- a/src/renderer/src/pages/network.tsx
+++ b/src/renderer/src/pages/network.tsx
@@ -318,9 +318,17 @@ const IPPage: React.FC = () => {
     [cardOrder, patchAppConfig]
   )
 
-  const customLatencyTargets = useMemo(
-    () => normalizeLatencyTargets(appConfig?.networkLatencyTargets),
+  // 每次 patchAppConfig 后 appConfig 都是重新反序列化出来的新对象，networkLatencyTargets
+  // 即使内容没变也是新数组引用；直接拿它当依赖会让下面整条 useMemo/useCallback 链失效，
+  // 进而触发自动测速 effect 重跑。这里用序列化结果做稳定依赖，内容真变了才重新计算。
+  const latencyTargetsKey = useMemo(
+    () => JSON.stringify(normalizeLatencyTargets(appConfig?.networkLatencyTargets)),
     [appConfig?.networkLatencyTargets]
+  )
+
+  const customLatencyTargets = useMemo(
+    () => JSON.parse(latencyTargetsKey) as INetworkLatencyTarget[],
+    [latencyTargetsKey]
   )
 
   const latencyTargets = useMemo(() => {

--- a/src/renderer/src/pages/sniffer.tsx
+++ b/src/renderer/src/pages/sniffer.tsx
@@ -73,6 +73,18 @@ const Sniffer: React.FC = () => {
       }
     })
   }
+  // 端口输入是受控的，编辑中途必须保留空项（否则刚敲的逗号会被立刻抹掉），
+  // 所以只在保存时剔除空端口：[''] 写进 mihomo.yaml 会让内核解析失败、无法启动
+  const buildSniffPayload = (): IMihomoSnifferConfig['sniff'] => {
+    const cleanPorts = (ports?: (number | string)[]): (number | string)[] =>
+      (ports ?? []).filter((port) => String(port).trim() !== '')
+    return {
+      ...values.sniff,
+      HTTP: { ...values.sniff.HTTP, ports: cleanPorts(values.sniff.HTTP?.ports) },
+      TLS: { ...values.sniff.TLS, ports: cleanPorts(values.sniff.TLS?.ports) },
+      QUIC: { ...values.sniff.QUIC, ports: cleanPorts(values.sniff.QUIC?.ports) }
+    }
+  }
   const handleListChange = (type: string, value: string, index: number): void => {
     const list = [...values[type]]
     if (value.trim()) {
@@ -130,7 +142,7 @@ const Sniffer: React.FC = () => {
                   'parse-pure-ip': values.parsePureIP,
                   'force-dns-mapping': values.forceDNSMapping,
                   'override-destination': values.overrideDestination,
-                  sniff: values.sniff,
+                  sniff: buildSniffPayload(),
                   'skip-domain': values.skipDomain,
                   'force-domain': values.forceDomain,
                   'skip-dst-address': values.skipDstAddress,

--- a/src/renderer/src/utils/calc.ts
+++ b/src/renderer/src/utils/calc.ts
@@ -35,7 +35,8 @@ export function calcPercent(
   download: number | undefined,
   total: number | undefined
 ): number {
-  if (upload === undefined || download === undefined || total === undefined) {
+  // total 为 0 是机场表示「不限量」的合法值，直接相除会得到 Infinity / NaN
+  if (upload === undefined || download === undefined || !total || total <= 0) {
     return 100
   }
   return Math.round(((upload + download) / total) * 100)

--- a/src/renderer/src/utils/validate.ts
+++ b/src/renderer/src/utils/validate.ts
@@ -27,6 +27,8 @@ const WINDOWS_PATH_PATTERN = /^[a-zA-Z]:[\\/].+/
 const UNIX_PATH_PATTERN = /^\/.+/
 const ANDROID_PACKAGE_PATTERN = /^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$/i
 const PROCESS_NAME_PATTERN = /^[a-zA-Z0-9._-]+$/
+// Windows 上常见的前缀通配写法，如 *\chrome.exe：不是绝对路径，替换通配符后仍不匹配
+const PREFIX_WILDCARD_PATH_PATTERN = /^[*?][^\\/]*[\\/].+/
 
 const isValidRegex: BooleanValidator = (value) => {
   try {
@@ -151,7 +153,8 @@ export const processPathValidator: BooleanValidator = (value) =>
   ANDROID_PACKAGE_PATTERN.test(value)
 
 export const processPathWildcardValidator: BooleanValidator = (value) =>
-  value.length > 0 && processPathValidator(replaceWildcards(value))
+  value.length > 0 &&
+  (processPathValidator(replaceWildcards(value)) || PREFIX_WILDCARD_PATH_PATTERN.test(value))
 
 export const processPathRegexValidator = isValidRegex
 


### PR DESCRIPTION
fix: correct sniffer ports, delay-test deps, debouncing and edge cases

- Clearing the sniff port input stored [''] rather than [], and the core
  rejects an empty string where a port is expected, so the config failed
  to load. Drop empty entries.

- The network page's latency test memoised on array identity, so any
  unrelated patchAppConfig re-created the dependency and re-ran the whole
  test sweep.

- mihomo-config and substore-config built their debounced writers inline
  during render, so every keystroke got a fresh timer and the debounce
  never applied - each character rewrote the config file.

- calcPercent guarded undefined but not total === 0, so an unlimited
  subscription rendered its usage bar as NaN.

- The PROCESS-PATH-WILDCARD validator rejected paths starting with a
  wildcard on Windows - which is the form the UI's own example uses.

---
Verified on Windows 11: `pnpm run review` (prettier + eslint + tsc) and `pnpm run test` (176 tests) pass, and `electron-vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
