### PR TITLE
fix: load legacy sysproxy binding on Windows 8/8.1

### DIFF
--- a/src/native/sysproxy/index.js
+++ b/src/native/sysproxy/index.js
@@ -1,17 +1,16 @@
 const { existsSync } = require('fs')
 const { join, dirname } = require('path')
 const os = require('os')
+const { usesLegacyWindowsBinding } = require('./windows-version')
 
 const { platform, arch } = process
 
 let nativeBinding = null
 let loadError = null
 
-function isWindows7() {
+function isLegacyWindows() {
   if (platform !== 'win32') return false
-  const release = os.release()
-  // Windows 7 is NT 6.1
-  return release.startsWith('6.1')
+  return usesLegacyWindowsBinding(os.release())
 }
 
 function isMusl() {
@@ -31,13 +30,15 @@ function isMusl() {
 }
 
 function getBindingName() {
-  const win7 = isWindows7()
+  const legacyWindows = isLegacyWindows()
   switch (platform) {
     case 'win32':
       if (arch === 'x64')
-        return win7 ? 'sysproxy.win32-x64-msvc-win7.node' : 'sysproxy.win32-x64-msvc.node'
+        return legacyWindows ? 'sysproxy.win32-x64-msvc-win7.node' : 'sysproxy.win32-x64-msvc.node'
       if (arch === 'ia32')
-        return win7 ? 'sysproxy.win32-ia32-msvc-win7.node' : 'sysproxy.win32-ia32-msvc.node'
+        return legacyWindows
+          ? 'sysproxy.win32-ia32-msvc-win7.node'
+          : 'sysproxy.win32-ia32-msvc.node'
       if (arch === 'arm64') return 'sysproxy.win32-arm64-msvc.node'
       break
     case 'darwin':

--- a/src/native/sysproxy/windows-version.js
+++ b/src/native/sysproxy/windows-version.js
@@ -1,0 +1,8 @@
+function usesLegacyWindowsBinding(release) {
+  const [major, minor] = release.split('.').map(Number)
+
+  // Windows 7, 8, and 8.1 report NT 6.1, 6.2, and 6.3 respectively.
+  return major === 6 && minor >= 1 && minor <= 3
+}
+
+module.exports = { usesLegacyWindowsBinding }

--- a/src/native/sysproxy/windows-version.test.ts
+++ b/src/native/sysproxy/windows-version.test.ts
@@ -1,0 +1,20 @@
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const { usesLegacyWindowsBinding } = require('./windows-version.js') as {
+  usesLegacyWindowsBinding: (release: string) => boolean
+}
+
+describe('usesLegacyWindowsBinding', () => {
+  it.each([
+    ['6.1.7601', true],
+    ['6.2.9200', true],
+    ['6.3.9600', true],
+    ['6.0.6002', false],
+    ['10.0.19045', false],
+    ['10.0.26100', false]
+  ])('maps Windows release %s to %s', (release, expected) => {
+    expect(usesLegacyWindowsBinding(release)).toBe(expected)
+  })
+})


### PR DESCRIPTION
## Summary

- treat Windows 8 (NT 6.2) and Windows 8.1 (NT 6.3) as legacy Windows when selecting the sysproxy native binding
- keep Windows 7 behavior unchanged
- add regression coverage for Windows 7, 8, 8.1, 10, and 11 release values

## Root cause

The Win7/8 build is prepared with `LEGACY_BUILD=true`, so it packages only the `sysproxy.*-msvc-win7.node` binding. At runtime, however, `isWindows7()` selected that binding only when `os.release()` started with `6.1`.

Windows 8 and 8.1 report NT 6.2 and 6.3. The app therefore searched for the non-packaged `sysproxy.win32-x64-msvc.node` (or ia32 equivalent) and crashed in the main process with:

```text
Native binding not found: sysproxy.win32-x64-msvc.node
```

## Impact

Win7/8 packages can now start correctly on Windows 8 and Windows 8.1 for both x64 and ia32 builds.

## Validation

- `pnpm test` — 24 files, 191 tests passed
- `pnpm run typecheck:node` — passed
- `pnpm run typecheck:web` — passed
- `pnpm run lint:check` — 0 errors (13 pre-existing warnings)
- Prettier check for all changed files — passed
