### PR TITLE
ci: 在 PR 与 push 上运行 lint / typecheck / format / 单测

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - smart_core
+      - main
+    paths-ignore:
+      - 'README.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/workflows/issues.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Lint, typecheck & format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      # --ignore-scripts skips the prepare step that downloads the mihomo cores;
+      # none of the static checks or unit tests need the sidecar binaries.
+      - name: Install dependencies
+        run: pnpm install --ignore-scripts
+      - name: Format check
+        run: pnpm run format:check
+      - name: Lint
+        run: pnpm run lint:check
+      - name: Typecheck
+        run: pnpm run typecheck
+
+  test:
+    name: Unit tests (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --ignore-scripts
+      - name: Test
+        run: pnpm test


### PR DESCRIPTION
现有的 `build.yml` 只在 `v*` tag 触发，且从不调用测试，因此 pull request 得不到任何自动检查。

本 PR 新增一个轻量的 CI workflow（`.github/workflows/ci.yml`），在 `pull_request` 与 `push` 时运行：

- `format:check` + `lint:check` + `typecheck`（在 ubuntu 上跑一次）
- 单元测试（ubuntu 与 windows 双平台矩阵）

安装依赖用 `pnpm install --ignore-scripts` 跳过内核下载 —— 静态检查和单测都不需要 sidecar 二进制。

不改动既有的发布流水线 `build.yml`，纯增量。