### PR TITLE
perf: 冷门语言改为按需加载,主进程产物减少 174 KB

### DIFF
--- a/src/main/utils/ipc.ts
+++ b/src/main/utils/ipc.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import v8 from 'v8'
 import { readFile } from 'fs/promises'
 import { app, ipcMain } from 'electron'
-import i18next from 'i18next'
+import { changeLanguage as changeI18nLanguage } from '../../shared/i18n'
 import {
   mihomoChangeProxy,
   mihomoCloseAllConnections,
@@ -219,7 +219,7 @@ async function measureLatency(url: string): Promise<number | null> {
 }
 
 async function changeLanguage(lng: string): Promise<void> {
-  await i18next.changeLanguage(lng)
+  await changeI18nLanguage(lng)
   ipcMain.emit('updateTrayMenu')
 }
 

--- a/src/renderer/src/components/settings/general-config.tsx
+++ b/src/renderer/src/components/settings/general-config.tsx
@@ -40,6 +40,7 @@ import { useTheme } from 'next-themes'
 import { IoIosArrowDown, IoIosHelpCircle, IoMdCloudDownload } from 'react-icons/io'
 import { MdEditDocument } from 'react-icons/md'
 import { useTranslation } from 'react-i18next'
+import { changeLanguage } from '../../../../shared/i18n'
 import SettingItem from '../base/base-setting-item'
 import SettingCard from '../base/base-setting-card'
 import BaseConfirmModal from '../base/base-confirm-modal'
@@ -52,7 +53,7 @@ type TrayIconCropTarget = 'custom' | keyof ICustomTrayIcons
 const customTrayIconStateKeys: (keyof ICustomTrayIcons)[] = ['off', 'sysProxy', 'tun']
 
 const GeneralConfig: React.FC = () => {
-  const { t, i18n } = useTranslation()
+  const { t } = useTranslation()
   const { data: enable = false, mutate: mutateEnable } = useSWR('checkAutoRun', checkAutoRun)
   const { appConfig, patchAppConfig } = useAppConfig()
   const [customThemes, setCustomThemes] = useState<{ key: string; label: string }[]>()
@@ -233,7 +234,7 @@ const GeneralConfig: React.FC = () => {
             onSelectionChange={async (v) => {
               const newLang = Array.from(v)[0] as 'zh-CN' | 'zh-TW' | 'en-US' | 'ru-RU' | 'fa-IR'
               await patchAppConfig({ language: newLang })
-              i18n.changeLanguage(newLang)
+              await changeLanguage(newLang)
             }}
           >
             <SelectItem key="en-US">English</SelectItem>

--- a/src/shared/i18n.test.ts
+++ b/src/shared/i18n.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import i18next from 'i18next'
+import { initI18n, changeLanguage, supportedLanguages } from './i18n'
+
+// Regression guard: addResourceBundle is only bound onto the i18next instance
+// after init(), so loading a lazy locale before initialisation throws.
+describe('i18n lazy locale loading', () => {
+  it('initialises directly into a lazily-loaded language', async () => {
+    await initI18n({ lng: 'zh-TW' })
+    expect(i18next.isInitialized).toBe(true)
+    expect(i18next.language).toBe('zh-TW')
+    expect(i18next.t('settings.language')).not.toBe('settings.language')
+  })
+
+  it('switches to another lazily-loaded language', async () => {
+    await changeLanguage('ru-RU')
+    expect(i18next.language).toBe('ru-RU')
+    expect(i18next.t('settings.language')).not.toBe('settings.language')
+  })
+
+  it('switches back to a bundled language', async () => {
+    await changeLanguage('zh-CN')
+    expect(i18next.language).toBe('zh-CN')
+    expect(i18next.t('settings.language')).not.toBe('settings.language')
+  })
+
+  it('resolves every supported language', async () => {
+    for (const lng of supportedLanguages) {
+      await changeLanguage(lng)
+      expect(i18next.t('settings.language'), `${lng} failed`).not.toBe('settings.language')
+    }
+  })
+})

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -1,26 +1,36 @@
 import i18next from 'i18next'
 import enUS from '../renderer/src/locales/en-US.json'
 import zhCN from '../renderer/src/locales/zh-CN.json'
-import zhTW from '../renderer/src/locales/zh-TW.json'
-import ruRU from '../renderer/src/locales/ru-RU.json'
-import faIR from '../renderer/src/locales/fa-IR.json'
 
+// en-US and zh-CN stay bundled: safeShowErrorBox() needs a translation
+// synchronously, before i18next has been initialised. The remaining locales are
+// loaded on demand, so a build no longer carries every translation into both the
+// main and the renderer bundle when only one language is ever active.
 export const resources = {
   'en-US': {
     translation: enUS
   },
   'zh-CN': {
     translation: zhCN
-  },
-  'zh-TW': {
-    translation: zhTW
-  },
-  'ru-RU': {
-    translation: ruRU
-  },
-  'fa-IR': {
-    translation: faIR
   }
+}
+
+const lazyLoaders: Record<string, () => Promise<{ default: Record<string, unknown> }>> = {
+  'zh-TW': () => import('../renderer/src/locales/zh-TW.json'),
+  'ru-RU': () => import('../renderer/src/locales/ru-RU.json'),
+  'fa-IR': () => import('../renderer/src/locales/fa-IR.json')
+}
+
+export const supportedLanguages = [...Object.keys(resources), ...Object.keys(lazyLoaders)]
+
+const loadedLazyLanguages = new Set<string>()
+
+async function ensureLanguage(lng: string): Promise<void> {
+  const loader = lazyLoaders[lng]
+  if (!loader || loadedLazyLanguages.has(lng)) return
+  const resource = await loader()
+  i18next.addResourceBundle(lng, 'translation', resource.default, true, true)
+  loadedLazyLanguages.add(lng)
 }
 
 export const defaultConfig = {
@@ -32,12 +42,22 @@ export const defaultConfig = {
   }
 }
 
-export const initI18n = async (options = {}): Promise<typeof i18next> => {
+export const initI18n = async (options: { lng?: string } = {}): Promise<typeof i18next> => {
+  if (options.lng) {
+    await ensureLanguage(options.lng)
+  }
   await i18next.init({
     ...defaultConfig,
     ...options
   })
   return i18next
+}
+
+// Load the bundle before switching, so the first render after a language change
+// is already translated rather than falling back to raw keys.
+export const changeLanguage = async (lng: string): Promise<void> => {
+  await ensureLanguage(lng)
+  await i18next.changeLanguage(lng)
 }
 
 export default i18next

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -25,6 +25,8 @@ export const supportedLanguages = [...Object.keys(resources), ...Object.keys(laz
 
 const loadedLazyLanguages = new Set<string>()
 
+// Must run after i18next.init(): addResourceBundle is only bound onto the
+// instance once initialisation has created the resource store.
 async function ensureLanguage(lng: string): Promise<void> {
   const loader = lazyLoaders[lng]
   if (!loader || loadedLazyLanguages.has(lng)) return
@@ -43,20 +45,28 @@ export const defaultConfig = {
 }
 
 export const initI18n = async (options: { lng?: string } = {}): Promise<typeof i18next> => {
-  if (options.lng) {
-    await ensureLanguage(options.lng)
-  }
+  const target = options.lng
+  const lazyTarget = target && target in lazyLoaders
+  // Initialise with a bundled language first: addResourceBundle only exists on
+  // the instance after init(), so a lazy language cannot be supplied up front.
   await i18next.init({
     ...defaultConfig,
-    ...options
+    ...options,
+    lng: lazyTarget ? 'en-US' : options.lng || defaultConfig.lng
   })
+  if (lazyTarget && target) {
+    await ensureLanguage(target)
+    await i18next.changeLanguage(target)
+  }
   return i18next
 }
 
 // Load the bundle before switching, so the first render after a language change
 // is already translated rather than falling back to raw keys.
 export const changeLanguage = async (lng: string): Promise<void> => {
-  await ensureLanguage(lng)
+  if (i18next.isInitialized) {
+    await ensureLanguage(lng)
+  }
   await i18next.changeLanguage(lng)
 }
 


### PR DESCRIPTION
`src/shared/i18n.ts` 静态 import 了全部 5 份 locale(合计约 279 KB JSON),而这个文件**同时被主进程和渲染层 import**,所以两个 bundle 各自都带了一份全量翻译——尽管任何时刻只有一种语言在用。

本 PR:

- 保留 `en-US` 和 `zh-CN` 静态打包 —— `safeShowErrorBox()` 需要在 i18next 初始化完成前**同步**取到翻译,这两份不能变成异步。
- `zh-TW` / `ru-RU` / `fa-IR` 改为 `import()` 按需加载。
- 新增 `changeLanguage()`:切换前先把对应语言包加载好再切,避免切换瞬间界面显示 raw key。主进程的 `changeLanguage` IPC 与设置页的语言下拉都改用它。

实测(`electron-vite build`):

| | 改动前 | 改动后 |
|---|---|---|
| `out/main/index.js` | 3,032,423 字节 | **2,854,077 字节**(-178,346) |

渲染层则拆出 `zh-TW` / `ru-RU` / `fa-IR` 三个独立 chunk,只在用户切到该语言时才加载。

验证:`typecheck:node` / `typecheck:web` 通过,全套单测通过,`eslint` 干净。