### PR TITLE
build: 把从分支 tip 拉取的两个下载钉到具体 commit

### DIFF
--- a/scripts/prepare.mjs
+++ b/scripts/prepare.mjs
@@ -456,10 +456,14 @@ const resolveMonitor = async () => {
   console.log(`[INFO]: TrafficMonitor finished`)
 }
 
+// Pinned to a commit instead of the branch tip: this is an executable that gets
+// shipped, and a branch tip can change at any time without review.
+const SEVEN_ZIP_BIN_COMMIT = '234abf56ddc2935de44e07d5e3c40eecab95d5af'
+
 const resolve7zip = () =>
   resolveResource({
     file: '7za.exe',
-    downloadURL: `https://github.com/develar/7zip-bin/raw/master/win/${arch}/7za.exe`
+    downloadURL: `https://github.com/develar/7zip-bin/raw/${SEVEN_ZIP_BIN_COMMIT}/win/${arch}/7za.exe`
   })
 const resolveSubstore = () =>
   resolveResource({
@@ -493,6 +497,10 @@ const resolveSubstoreFrontend = async () => {
 
   console.log(`[INFO]: sub-store-frontend finished`)
 }
+// Pinned to a commit instead of the branch tip, so the bundled font cannot
+// change underneath a build.
+const NOTO_EMOJI_COMMIT = '8998f5dd683424a73e2314a8c1f1e359c19e8742'
+
 const resolveFont = async () => {
   const targetPath = path.join(cwd, 'src', 'renderer', 'src', 'assets', 'NotoColorEmoji.ttf')
 
@@ -500,7 +508,7 @@ const resolveFont = async () => {
     return
   }
   await downloadFile(
-    'https://github.com/googlefonts/noto-emoji/raw/main/fonts/NotoColorEmoji.ttf',
+    `https://github.com/googlefonts/noto-emoji/raw/${NOTO_EMOJI_COMMIT}/fonts/NotoColorEmoji.ttf`,
     targetPath
   )
 


### PR DESCRIPTION
`scripts/prepare.mjs` 里有两个文件是直接从**分支 tip** 拉的:

```
https://github.com/develar/7zip-bin/raw/master/win/<arch>/7za.exe
https://github.com/googlefonts/noto-emoji/raw/main/fonts/NotoColorEmoji.ttf
```

分支 tip 随时可能变、没有版本、也没有审阅环节,而其中第一个是**会打进发布包的可执行文件**。同一条命令在不同时间构建出来的产物可能不一样。

本 PR 把这两个钉到它们当前解析到的 commit:

- `develar/7zip-bin` → `234abf56ddc2935de44e07d5e3c40eecab95d5af`(该仓库 master 自 2022-05 起未再变动)
- `googlefonts/noto-emoji` → `8998f5dd683424a73e2314a8c1f1e359c19e8742`

**发布 tag 类的下载(`Prerelease-Alpha`、`releases/latest` 等)一律不动** —— 那些按设计就是滚动的,钉住只会让构建天天失败,不是加固。

验证:`node --check scripts/prepare.mjs` 通过;已确认钉住的 commit 下目标文件存在。