### PR TITLE
ci: macOS 公证后补上 stapler staple

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -406,6 +406,7 @@ jobs:
             productsign --sign "Developer ID Installer: Prometheus Advertising Corp (489PDK5LP3)" Unsigned-Workbench.pkg $pkg_name
             rm -f Unsigned-Workbench.pkg
             xcrun notarytool submit $pkg_name --apple-id $APPLE_ID --team-id $APPLE_TEAM_ID --password $APPLE_APP_SPECIFIC_PASSWORD --wait
+            xcrun stapler staple $pkg_name
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -508,6 +509,7 @@ jobs:
             productsign --sign "Developer ID Installer: Prometheus Advertising Corp (489PDK5LP3)" Unsigned-Workbench.pkg $pkg_name
             rm -f Unsigned-Workbench.pkg
             xcrun notarytool submit $pkg_name --apple-id $APPLE_ID --team-id $APPLE_TEAM_ID --password $APPLE_APP_SPECIFIC_PASSWORD --wait
+            xcrun stapler staple $pkg_name
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`macos` 和 `macos10` 两个 job 都把签名后的 `.pkg` 提交给 `notarytool` 公证了,但**没有把公证票据装订(staple)回安装包**。

没有装订票据的后果:Gatekeeper 必须联网向 Apple 的公证服务查询才能验证。对这个应用来说这个场景相当常见——用户往往正是在**网络受限或断网的状态下**才要装它——此时安装会报「无法打开,因为 Apple 无法检查其是否包含恶意软件」。

`xcrun stapler staple` 是 Developer ID 分发流程文档里的最后一步,本 PR 在公证成功后各补一行。

顺带说明:`electron-builder.yml` 里的 `notarize: false` 我确认过**不是问题** —— 实际分发物是 `.pkg`,而它已经由 CI 单独用 `notarytool` 公证了;electron-builder 的 notarize 针对的是 `.app`/`.dmg`,不是这里的分发物。真正缺的只是装订这一步。