### PR TITLE
fix: 连接建立时补充流重连配额,修复连接页空白 / 流量显示 0KB

### DIFF
--- a/src/main/core/mihomoApi.stream.test.ts
+++ b/src/main/core/mihomoApi.stream.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+
+// A stream that the core has nothing to say on yet — /connections while no
+// connection is open is the common case — used to burn its entire retry budget
+// on idle reconnects and then stay dead for the rest of the session, because
+// the budget was only replenished by an incoming message.
+
+const sockets: FakeSocket[] = []
+
+class FakeSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  readyState = FakeSocket.CONNECTING
+  onopen: (() => void) | null = null
+  onmessage: ((e: { data: string }) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: ((e?: unknown) => void) | null = null
+  removeAllListeners = vi.fn()
+  close = vi.fn()
+  terminate = vi.fn()
+
+  constructor() {
+    sockets.push(this)
+  }
+
+  open(): void {
+    this.readyState = FakeSocket.OPEN
+    this.onopen?.()
+  }
+
+  drop(): void {
+    this.readyState = 3
+    this.onclose?.()
+  }
+}
+
+vi.mock('ws', () => ({ default: FakeSocket }))
+vi.mock('net', () => ({ createConnection: vi.fn(() => ({})) }))
+vi.mock('electron', () => ({ app: { isReady: () => true } }))
+vi.mock('axios', () => ({
+  default: { create: () => ({ interceptors: { response: { use: vi.fn() } } }) }
+}))
+vi.mock('../config', () => ({ getAppConfig: vi.fn(), getControledMihomoConfig: vi.fn() }))
+vi.mock('../window', () => ({ mainWindow: null }))
+vi.mock('../resolve/tray', () => ({ tray: null }))
+vi.mock('../resolve/floatingWindow', () => ({ floatingWindow: null }))
+vi.mock('../utils/calc', () => ({ calcTraffic: () => '' }))
+vi.mock('../utils/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+vi.mock('../utils/dirs', () => ({ mihomoWorkConfigPath: () => '' }))
+vi.mock('./factory', () => ({ generateProfile: vi.fn(), getRuntimeConfig: vi.fn() }))
+vi.mock('./manager', () => ({
+  getMihomoIpcPath: () => '/tmp/fake.sock',
+  hasCoreProcess: () => true,
+  restartCore: vi.fn()
+}))
+
+describe('stream reconnect budget', () => {
+  beforeEach(() => {
+    sockets.length = 0
+    vi.resetModules()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps reconnecting past the retry cap when the socket opens but stays silent', async () => {
+    const { startMihomoConnections } = await import('./mihomoApi')
+    startMihomoConnections()
+
+    // Far more idle open/close cycles than MAX_RETRY (10). Every cycle opens
+    // successfully and never delivers a message, which is exactly the reported
+    // scenario.
+    for (let i = 0; i < 25; i++) {
+      const socket = sockets[sockets.length - 1]
+      expect(socket, `no socket for cycle ${i}`).toBeDefined()
+      socket.open()
+      socket.drop()
+      await vi.advanceTimersByTimeAsync(1000)
+    }
+
+    expect(sockets.length).toBeGreaterThan(11)
+  })
+
+  it('still gives up when the socket never opens at all', async () => {
+    const { startMihomoConnections } = await import('./mihomoApi')
+    startMihomoConnections()
+
+    for (let i = 0; i < 25; i++) {
+      const socket = sockets[sockets.length - 1]
+      if (!socket) break
+      socket.drop()
+      await vi.advanceTimersByTimeAsync(1000)
+    }
+
+    // A core that is genuinely unreachable must not be retried forever.
+    expect(sockets.length).toBeLessThanOrEqual(11)
+  })
+})

--- a/src/main/core/mihomoApi.ts
+++ b/src/main/core/mihomoApi.ts
@@ -64,6 +64,7 @@ function clearStreamReconnect(stream: MihomoStreamState): void {
 }
 
 function disposeStreamSocket(ws: WebSocket): void {
+  ws.onopen = null
   ws.onmessage = null
   ws.onclose = null
   ws.onerror = null
@@ -112,6 +113,17 @@ function beginStreamConnection(stream: MihomoStreamState): number | null {
 
 function isCurrentStream(stream: MihomoStreamState, generation: number): boolean {
   return stream.active && stream.generation === generation
+}
+
+// Replenish the retry budget as soon as the socket is established. Waiting for
+// the first message means a stream the core has nothing to say on yet — most
+// visibly /connections while no connection is open — burns its whole budget on
+// idle reconnects and then never comes back for the rest of the session.
+function armStreamSocket(stream: MihomoStreamState, generation: number, ws: WebSocket): void {
+  ws.onopen = (): void => {
+    if (!isCurrentStream(stream, generation)) return
+    stream.retry = MAX_RETRY
+  }
 }
 
 function scheduleStreamReconnect(
@@ -490,6 +502,7 @@ const mihomoTraffic = async (): Promise<void> => {
 
   mihomoApiLogger.info(`Creating traffic WebSocket with URL: ${wsUrl}, IPC path: ${ipcPath}`)
   trafficStream.ws = ws
+  armStreamSocket(trafficStream, generation, ws)
 
   ws.onmessage = (e): void => {
     if (!isCurrentStream(trafficStream, generation)) return
@@ -542,6 +555,7 @@ const mihomoMemory = async (): Promise<void> => {
 
   const { ws } = createMihomoWebSocket('/memory')
   memoryStream.ws = ws
+  armStreamSocket(memoryStream, generation, ws)
 
   ws.onmessage = (e): void => {
     if (!isCurrentStream(memoryStream, generation)) return
@@ -583,6 +597,7 @@ const mihomoLogs = async (): Promise<void> => {
 
   const { ws } = createMihomoWebSocket(`/logs?level=${logLevel}`)
   logsStream.ws = ws
+  armStreamSocket(logsStream, generation, ws)
 
   ws.onmessage = (e): void => {
     if (!isCurrentStream(logsStream, generation)) return
@@ -622,6 +637,7 @@ const mihomoConnections = async (): Promise<void> => {
 
   const { ws } = createMihomoWebSocket('/connections')
   connectionsStream.ws = ws
+  armStreamSocket(connectionsStream, generation, ws)
 
   ws.onmessage = (e): void => {
     if (!isCurrentStream(connectionsStream, generation)) return


### PR DESCRIPTION
可能修复 #1678、#1410(连接页面空白、流量一直显示 0KB,但代理可用、外部面板正常)。

## 问题

`src/main/core/mihomoApi.ts` 里四个 WebSocket 流的重试配额 `stream.retry` 只有两个补充点:流被 `activateStream()` 激活时,以及 `onmessage` 收到消息时。

于是「socket 已经连上、但在第一条消息到达之前就断开」这种循环里,配额**只减不增**。每秒一次、十次之后配额归零,`scheduleStreamReconnect` 直接 return,这条流在本次会话里就再也不会重连了 —— 只有内核重启走到 `startMihomoApiStreams()` 重新 `activate` 才会恢复。

REST 接口(节点列表、外部面板)走的是 axios 那条路,不受影响。这正好解释了 issue 里描述的现象:代理照常能用、面板正常,唯独连接页空白、流量 0KB。

## 改动

补上缺失的第三个补充点:在 `onopen` 里重置配额,让它表达「我们连上了没有」而不是「消息有没有及时到达」。

- `onopen` 一并加入 `disposeStreamSocket()` 的清理,避免残留回调。
- 沿用既有的 generation 守卫,防止旧 socket 给新一代流补配额。
- **内核确实不可达时永远到不了 `onopen`,所以仍然会在 `MAX_RETRY` 次后放弃**,没有改成无限重连。

## 验证

新增 `mihomoApi.stream.test.ts`,mock 掉 `ws` 覆盖两个方向:

1. socket 能打开但一直没有消息 → 超过 10 次后仍在重连(修复前会停在 11 个 socket)
2. socket 从不打开 → 仍然在 `MAX_RETRY` 后放弃(确认没有引入无限重连)

删掉 `onopen` 里那行重置后第 1 条会失败,还原后恢复。

全量 193 个测试通过,`typecheck:node` / `typecheck:web` 与 `lint:check` 干净,`electron-vite build` 通过。

由于我没能稳定复现 issue 里的原始现场,这条按「机制上可证、能否解决报告者的问题待确认」提出,烦请review。