### PR TITLE
fix: allow named GEOIP categories

### DIFF
--- a/src/renderer/src/utils/validate.test.ts
+++ b/src/renderer/src/utils/validate.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+import { geoipValidator } from './validate'
+
+describe('geoipValidator', () => {
+  it('accepts named GeoIP categories', () => {
+    expect(geoipValidator('CN')).toBe(true)
+    expect(geoipValidator('PRIVATE')).toBe(true)
+    expect(geoipValidator('PRIVATE IP')).toBe(false)
+  })
+})

--- a/src/renderer/src/utils/validate.ts
+++ b/src/renderer/src/utils/validate.ts
@@ -121,10 +121,9 @@ const geositeValidator = (value: string): boolean => {
   return validator.isAlphanumeric(value, 'en-US', { ignore: '-_' }) && value.length > 0
 }
 
-// GEOIP 验证器 - 国家代码验证（ISO 3166-1 alpha-2）
+// GEOIP 验证器 - 国家代码或命名分类验证
 const geoipValidator = (value: string): boolean => {
-  // 支持 2 位国家代码（大小写不敏感）
-  return validator.isAlpha(value) && value.length === 2
+  return geositeValidator(value)
 }
 
 // ASN 验证器 - 自治系统号验证


### PR DESCRIPTION
Fixes #2108

Allow named GEOIP categories such as `PRIVATE` in the rule editor.

Added a small regression test.