### PR TITLE
fix: apply Smart core settings on hot reload and stop re-downloading the model

### DIFF
--- a/src/main/config/smartOverride.ts
+++ b/src/main/config/smartOverride.ts
@@ -1,6 +1,6 @@
 import { overrideLogger } from '../utils/logger'
 import { getAppConfig } from './app'
-import { addOverrideItem, removeOverrideItem, getOverrideItem } from './override'
+import { addOverrideItem, removeOverrideItem, getOverrideItem, getOverride } from './override'
 
 const SMART_OVERRIDE_ID = 'smart-core-override'
 
@@ -376,6 +376,13 @@ export async function createSmartOverride(): Promise<void> {
       smartCoreStrategy,
       smartCollectorSize
     )
+
+    // 热重载每次生效前都会重新生成覆写，内容未变时跳过写盘，避免无谓的时间戳刷新
+    const existing = await getOverrideItem(SMART_OVERRIDE_ID)
+    if (existing) {
+      const current = await getOverride(SMART_OVERRIDE_ID, 'js')
+      if (current === template) return
+    }
 
     await addOverrideItem({
       id: SMART_OVERRIDE_ID,

--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -46,6 +46,7 @@ import {
   getAxios
 } from './mihomoApi'
 import { generateProfile } from './factory'
+import { syncSmartModelToTestDir } from './smartModel'
 import {
   checkAdminRestartForTun as checkAdminRestartForTunWithRestart,
   getSessionAdminStatus,
@@ -945,6 +946,7 @@ export async function checkProfileConfig(
   ageSecretKey?: string
 ): Promise<void> {
   const corePath = mihomoCorePath(core)
+  await syncSmartModelToTestDir()
 
   try {
     await execFilePromise(corePath, ['-t', '-f', configPath, '-d', mihomoTestDir()], {

--- a/src/main/core/mihomoApi.ts
+++ b/src/main/core/mihomoApi.ts
@@ -2,7 +2,7 @@ import { createConnection } from 'net'
 import axios, { AxiosInstance } from 'axios'
 import WebSocket from 'ws'
 import { app } from 'electron'
-import { getAppConfig, getControledMihomoConfig } from '../config'
+import { getAppConfig, getControledMihomoConfig, manageSmartOverride } from '../config'
 import { mainWindow } from '../window'
 import { tray } from '../resolve/tray'
 import { calcTraffic } from '../utils/calc'
@@ -434,6 +434,9 @@ export const mihomoHotReloadConfig = async (): Promise<void> => {
     await restartCore()
     return
   }
+  // Smart 覆写脚本由应用配置生成，必须先同步再生成配置，
+  // 否则界面上改动的 Smart 选项会沿用旧脚本，要等到下次重启内核才生效
+  await manageSmartOverride()
   const current = await generateProfile()
   const { diffWorkDir = false } = await getAppConfig()
   const configPath = diffWorkDir ? mihomoWorkConfigPath(current) : mihomoWorkConfigPath('work')

--- a/src/main/core/smartModel.ts
+++ b/src/main/core/smartModel.ts
@@ -1,0 +1,34 @@
+import { copyFile, stat } from 'fs/promises'
+import { existsSync } from 'fs'
+import path from 'path'
+import { mihomoWorkDir, mihomoTestDir } from '../utils/dirs'
+import { managerLogger } from '../utils/logger'
+
+const MODEL_FILE = 'Model.bin'
+
+async function isSourceNewer(sourcePath: string, targetPath: string): Promise<boolean> {
+  try {
+    const [sourceStats, targetStats] = await Promise.all([stat(sourcePath), stat(targetPath)])
+    return sourceStats.mtime > targetStats.mtime
+  } catch {
+    return true
+  }
+}
+
+// Smart 内核在工作目录找不到 Model.bin 时会联网下载模型。而配置检查（mihomo -t）跑在独立的
+// test 目录里，该目录从不包含模型；这次检查又发生在旧内核已经停止、系统代理已经撤下之后，
+// 于是下载必然超时失败，每次重启白白多等约 20 秒，且失败不留文件，下次重启重演一遍。
+// 正式工作目录已有模型时先同步过去，跳过这次注定失败的下载。
+export async function syncSmartModelToTestDir(): Promise<void> {
+  const source = path.join(mihomoWorkDir(), MODEL_FILE)
+  if (!existsSync(source)) return
+
+  const target = path.join(mihomoTestDir(), MODEL_FILE)
+  if (existsSync(target) && !(await isSourceNewer(source, target))) return
+
+  try {
+    await copyFile(source, target)
+  } catch (error) {
+    managerLogger.warn('Failed to sync Model.bin into test dir', error)
+  }
+}


### PR DESCRIPTION
Two Smart core fixes.

### Smart settings only take effect after a core restart

The Smart toggles are written into the auto-generated global override script, but the function that regenerates that script, `manageSmartOverride()`, only runs from `prepareCore()`. The settings page calls `patchAppConfig()` + `mihomoHotReloadConfig()`, and `mihomoHotReloadConfig()` goes straight to `generateProfile()`, which applies whatever script is already on disk. So the app config can say `smartCoreUseLightGBM: true` while every generated Smart group still says `uselightgbm: false`, until the core happens to be restarted.

`mihomoHotReloadConfig()` now regenerates the override before generating the profile. `createSmartOverride()` compares the new script against the stored one and skips the write when nothing changed, so hot reload no longer bumps the override's `updated` timestamp on every call. de8ebb2 added another path that goes through hot reload, which makes this easier to hit than before.

### Every profile check re-downloads Model.bin

The Smart core downloads `Model.bin` when it is missing from its working directory. `checkProfileConfig()` runs the core with `-d <test dir>`, and that directory never receives the model: `initFiles()` only copies the bundled geo databases there, and the model is a runtime download rather than a bundled resource.

The check also runs after the previous core has been stopped and the system proxy torn down, so the download times out instead of completing, and a failed download can leave a truncated file behind, which makes every later check fail outright (see the comment below). Measured on Windows: 20.1s for a restart that hit the failed download, against 0.5s for the same check with the model already present in the test dir.

`checkProfileConfig()` now copies the model over from the working directory first, mirroring how the geo databases are already shared with the test dir. It copies only when the test copy is missing or older than the source, and warns and continues if the copy fails, so the worst case is today's behaviour. `checkProfileConfig()` is the single point both callers go through (core restart, and the check before replacing a profile), so one call covers both.

4 files, +48/-2. typecheck and lint are clean.