### PR TITLE
fix: let users recover from a crash without restarting the app

### DIFF
--- a/src/renderer/src/components/base/base-error-boundary.tsx
+++ b/src/renderer/src/components/base/base-error-boundary.tsx
@@ -12,10 +12,15 @@ const ErrorFallback = ({ error }: FallbackProps): React.ReactElement => {
     <div className="p-4">
       <h2 className="my-2 text-lg font-bold">{t('common.error.appCrash')}</h2>
 
+      {/* 崩溃后整棵组件树都被替换掉，此前只能杀进程重启；重新加载渲染进程即可回到可用状态 */}
+      <Button size="sm" color="primary" onPress={() => location.reload()}>
+        {t('common.error.reload')}
+      </Button>
       <Button
         size="sm"
         color="primary"
         variant="flat"
+        className="ml-2"
         onPress={() => open('https://github.com/mihomo-party-org/mihomo-party/issues/new/choose')}
       >
         GitHub

--- a/src/renderer/src/locales/en-US.json
+++ b/src/renderer/src/locales/en-US.json
@@ -31,6 +31,7 @@
   "common.notification.globalMode": "Global Mode",
   "common.notification.directMode": "Direct Mode",
   "common.error.appCrash": "Application crashed :( Please submit the following information to the developer to troubleshoot",
+  "common.error.reload": "Reload",
   "common.error.copyErrorMessage": "Copy Error Message",
   "common.error.invalidCron": "Invalid Cron expression",
   "common.error.getBackupListFailed": "Failed to get backup list: {{error}}",

--- a/src/renderer/src/locales/fa-IR.json
+++ b/src/renderer/src/locales/fa-IR.json
@@ -31,6 +31,7 @@
   "common.notification.globalMode": "حالت جهانی",
   "common.notification.directMode": "حالت مستقیم",
   "common.error.appCrash": "برنامه دچار خطا شد :( لطفا اطلاعات زیر را برای رفع مشکل به توسعه‌دهنده ارسال کنید",
+  "common.error.reload": "بارگذاری مجدد",
   "common.error.copyErrorMessage": "کپی پیام خطا",
   "common.error.invalidCron": "عبارت Cron نامعتبر است",
   "common.error.getBackupListFailed": "دریافت لیست پشتیبان با خطا مواجه شد: {{error}}",

--- a/src/renderer/src/locales/ru-RU.json
+++ b/src/renderer/src/locales/ru-RU.json
@@ -31,6 +31,7 @@
   "common.notification.globalMode": "Глобальный",
   "common.notification.directMode": "Прямой",
   "common.error.appCrash": "Приложение завершилось аварийно :( Пожалуйста, отправьте следующую информацию разработчику для устранения проблемы",
+  "common.error.reload": "Перезагрузить",
   "common.error.copyErrorMessage": "Копировать сообщение об ошибке",
   "common.error.invalidCron": "Неверное выражение Cron",
   "common.error.getBackupListFailed": "Не удалось получить список резервных копий: {{error}}",

--- a/src/renderer/src/locales/zh-CN.json
+++ b/src/renderer/src/locales/zh-CN.json
@@ -31,6 +31,7 @@
   "common.notification.globalMode": "全局模式",
   "common.notification.directMode": "直连模式",
   "common.error.appCrash": "应用崩溃了 :( 请将以下信息提交给开发者以排查错误",
+  "common.error.reload": "重新加载",
   "common.error.copyErrorMessage": "复制报错信息",
   "common.error.invalidCron": "无效的 Cron 表达式",
   "common.error.getBackupListFailed": "获取备份列表失败：{{error}}",

--- a/src/renderer/src/locales/zh-TW.json
+++ b/src/renderer/src/locales/zh-TW.json
@@ -31,6 +31,7 @@
   "common.notification.globalMode": "全局模式",
   "common.notification.directMode": "直連模式",
   "common.error.appCrash": "應用崩潰了 :( 請將以下信息提交給開發者以排查錯誤",
+  "common.error.reload": "重新載入",
   "common.error.copyErrorMessage": "複製報錯信息",
   "common.error.invalidCron": "無效的 Cron 表達式",
   "common.error.getBackupListFailed": "獲取備份列表失敗：{{error}}",


### PR DESCRIPTION
The error boundary wraps the whole tree, so any render error replaces the entire window - sidebar included - with the fallback. The fallback only offers GitHub, Telegram and a copy button, and never resets, so the app stays on that screen until the user kills the process.

Add a reload button that reloads the renderer. The main process, the core and the system proxy are untouched, so a transient failure recovers in place; a persistent one lands back on the same screen, no worse than now.

The boundary sits in `main.tsx` outside `HashRouter`, so the fallback replaces the router and every provider too, not just the page that threw. `resetErrorBoundary()` would re-render the same tree, so a deterministic error crashes again straight away and looks broken; reloading the renderer re-runs the IPC calls that fetch config instead.

Adds `common.error.reload` to all five locales.

### Verified end to end

Loaded the built renderer in Electron with stubbed IPC, forcing a render error on the first load and returning good data after a reload. Same harness against the current branch tip for comparison:

| step | smart_core | with this change |
| --- | --- | --- |
| initial | renders, 62,824 bytes | renders, 62,824 bytes |
| after the error | 4,708 bytes, buttons `[GitHub, Telegram, Copy]` | 5,452 bytes, buttons `[Reload, GitHub, Telegram, Copy]` |
| click reload | no such button | clicked |
| after that | still 4,708, 1 page load, stuck | 132,790 bytes, 2 page loads, recovered |

6 files, 10 lines added. typecheck and lint clean, full suite passes.