### PR TITLE
fix: stop dropping tolerance when converting a group to Smart

### DIFF
--- a/src/main/config/smartOverride.ts
+++ b/src/main/config/smartOverride.ts
@@ -88,10 +88,9 @@ function main(config) {
             group.collectdata = ${collectData}
             group.strategy = '${strategy}'
             
-            // 移除 url-test 和 load-balance 特有的配置
+            // 移除 url-test 和 load-balance 特有的配置（tolerance 是 Smart 也支持的选项，保留）
             if (group.url) delete group.url
             if (group.interval) delete group.interval
-            if (group.tolerance) delete group.tolerance
             if (group.lazy) delete group.lazy
             if (group.expected_status) delete group['expected-status']
           }


### PR DESCRIPTION
The Smart override converts url-test and load-balance groups and then strips their type-specific keys. `tolerance` is in that list, but the Smart core supports it: `SmartOption.Tolerance` feeds the sort comparator, where delays within `tolerance` compare equal so the group stops flapping between nodes of near-identical latency.

Because a normal override always runs before the Smart one, this leaves no way to set `tolerance` at all while the auto override is on - a value in the subscription is deleted, and so is one set by an earlier override. The branch that handles an already-smart group never deleted it, so the two paths disagreed.

`SmartOption.Tolerance` is in `adapter/outboundgroup/smart.go` in the Smart core, and the sort comparator there treats two nodes as equal when their delays differ by no more than it. The ordering that makes this unreachable is in `factory.ts`: `overrideIds.normal` is applied, then the rule override, then `overrideIds.smart` last.

The other keys removed alongside it - `url`, `interval`, `lazy`, `expected-status` - are genuinely url-test/load-balance specific and stay removed.

1 file, +1/-2. typecheck and lint are clean.