### PR TITLE
fix(windows): request UAC before the app exits so the restart actually happens

### DIFF
--- a/src/main/core/permissions.ts
+++ b/src/main/core/permissions.ts
@@ -1,4 +1,4 @@
-import { exec, execFile } from 'child_process'
+import { exec, execFile, spawn } from 'child_process'
 import { promisify } from 'util'
 import { stat } from 'fs/promises'
 import { existsSync } from 'fs'
@@ -289,12 +289,19 @@ export async function restartAsAdmin(forTun: boolean = true): Promise<void> {
 
   managerLogger.info('Restarting as administrator with command', command)
 
-  // 先启动 PowerShell（它会等待 1 秒），然后立即退出当前进程
-  exec(command, { windowsHide: true }, (error) => {
-    if (error) {
-      managerLogger.error('Failed to start PowerShell for admin restart', error)
-    }
-  })
+  // 启动器必须脱离当前进程的生命周期：exec() 的子进程会随紧随其后的 app.exit(0) 一起消失，
+  // 提权命令根本来不及执行，用户看到的就是「应用直接退出、UAC 不弹、也没有重新启动」。
+  try {
+    spawn(command, {
+      shell: true,
+      windowsHide: true,
+      detached: true,
+      stdio: 'ignore'
+    }).unref()
+  } catch (error) {
+    managerLogger.error('Failed to start PowerShell for admin restart', error)
+    throw error
+  }
   managerLogger.info('PowerShell command started, quitting app immediately')
   app.exit(0)
 }


### PR DESCRIPTION
`restartAsAdmin()` launched the elevation helper with `exec()` and then called
`app.exit(0)` on the very next line. The helper is an ordinary child of the main
process, so it usually died before PowerShell was even created and
`Start-Process -Verb RunAs` never ran. Users see the app vanish with no UAC
prompt and no restart.

Measured with a real Electron 43.2.0 probe, 7 runs each:

| variant | helper survived |
| --- | --- |
| current `exec()` + `app.exit(0)` | 1 / 7 |
| `spawn(detached, stdio: 'ignore').unref()` | 7 / 7 |

A plain node probe puts the threshold around 20 ms of main-process delay: at 0 ms
the helper always dies. That is why this reproduces for some users and never for
others — it depends on how fast the machine is.

Detach the helper so it outlives the exiting main process.

Note: `spawn('powershell', [...], { detached: true })` without `shell: true` does
not work — powershell exits silently when it has no console — so the call keeps
going through cmd.exe.

Closes #1737