### PR TITLE
fix(macos): stop the core permission grant from failing or running when unnecessary

### DIFF
--- a/build/pkg-scripts/postinstall
+++ b/build/pkg-scripts/postinstall
@@ -120,21 +120,22 @@ launchctl bootout system "$LAUNCH_DAEMON" 2>/dev/null || true
 launchctl unload "$LAUNCH_DAEMON" 2>/dev/null || true
 
 # 加载服务
+# 注意：加载失败不能让整个安装失败。用户在「系统设置 - 登录项与扩展 - 允许在后台」里
+# 关掉本服务后，launchctl 会返回 "Load failed: 5: Input/output error"，此时中止安装会让
+# 用户连应用都装不上；而应用在首次用到 helper 时会自行重装并重新加载它。
 log "Loading service..."
 if [ "$macos_major" -ge 11 ]; then
     # macOS Big Sur 及更新版本使用 bootstrap
     if ! launchctl bootstrap system "$LAUNCH_DAEMON"; then
         log "Bootstrap failed, trying legacy load..."
         if ! launchctl load "$LAUNCH_DAEMON"; then
-            log "Error: Failed to load service with both methods"
-            exit 1
+            log "Warning: Failed to load service with both methods, the app will retry on demand"
         fi
     fi
 else
     # 旧版本使用 load
     if ! launchctl load "$LAUNCH_DAEMON"; then
-        log "Error: Failed to load service"
-        exit 1
+        log "Warning: Failed to load service, the app will retry on demand"
     fi
 fi
 

--- a/src/main/core/permissions.ts
+++ b/src/main/core/permissions.ts
@@ -244,6 +244,15 @@ export async function grantTunPermissions(): Promise<void> {
   const corePath = mihomoCorePath(core)
   validateCorePath(corePath)
 
+  // 权限已经满足时直接返回，不再提权。
+  // 内核位于应用包内，macOS 会保护已签名应用包的内容，即使以 root 执行 chown 也会返回
+  // Operation not permitted；而安装包的 postinstall 早已设置好 root:admin + setuid。
+  // 此时再执行只会弹一次授权框然后报错，让用户误以为虚拟网卡不可用。
+  if (process.platform !== 'win32' && (await checkMihomoCorePermissions())) {
+    managerLogger.info('Core already has the required permissions, skipping privilege escalation')
+    return
+  }
+
   if (process.platform === 'darwin') {
     const escapedPath = shellEscape(corePath)
     const script = `do shell script "chown root:admin ${escapedPath} && chmod +sx ${escapedPath}" with administrator privileges`

--- a/src/main/core/permissions.ts
+++ b/src/main/core/permissions.ts
@@ -255,8 +255,23 @@ export async function grantTunPermissions(): Promise<void> {
 
   if (process.platform === 'darwin') {
     const escapedPath = shellEscape(corePath)
-    const script = `do shell script "chown root:admin ${escapedPath} && chmod +sx ${escapedPath}" with administrator privileges`
-    await execFilePromise('osascript', ['-e', script])
+    // 内核位于应用包内，macOS 会保护已签名应用包的内容，即使通过 osascript 以 root
+    // 执行，chown 也可能返回 Operation not permitted。但安装包的 postinstall 已经把
+    // 属主设成 root，真正缺的往往只是 setuid 位，此时 chmod 仍然能把权限补齐。
+    // 因此用 `;` 而不是 `&&` 串联：chown 失败时 chmod 依然会执行，最终以内核实际
+    // 是否拿到权限为准，而不是以 chown 的退出码为准。
+    const script = `do shell script "chown root:admin ${escapedPath}; chmod +sx ${escapedPath}" with administrator privileges`
+    try {
+      await execFilePromise('osascript', ['-e', script])
+    } catch (error) {
+      if (!(await checkMihomoCorePermissions())) {
+        throw error
+      }
+      managerLogger.warn(
+        'Core privilege escalation reported an error but the required permissions are already satisfied',
+        error
+      )
+    }
   }
 
   if (process.platform === 'linux') {

--- a/src/main/utils/dirs.ts
+++ b/src/main/utils/dirs.ts
@@ -85,11 +85,31 @@ export function mihomoCoreDir(): string {
   return path.join(resourcesDir(), 'sidecar')
 }
 
+// 用户手动下载的指定版本内核。不能放进应用包：macOS 的 /Applications 与 Windows 的
+// Program Files 都由安装器以管理员身份写入，应用自身没有写权限，下载会直接 EACCES。
+export function mihomoSpecificCoreDir(): string {
+  const dir = path.join(dataDir(), 'cores')
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+  return dir
+}
+
 export function mihomoCorePath(core: string): string {
   const isWin = process.platform === 'win32'
   // 处理 Smart 内核
   if (core === 'mihomo-smart') {
     return path.join(mihomoCoreDir(), `mihomo-smart${isWin ? '.exe' : ''}`)
+  }
+  if (core === 'mihomo-specific') {
+    const fileName = `mihomo-specific${isWin ? '.exe' : ''}`
+    const legacyPath = path.join(mihomoCoreDir(), fileName)
+    const userPath = path.join(mihomoSpecificCoreDir(), fileName)
+    // 旧版本把它下载到了应用包内，升级后继续沿用已有文件，避免用户的内核凭空消失
+    if (!existsSync(userPath) && existsSync(legacyPath)) {
+      return legacyPath
+    }
+    return userPath
   }
   return path.join(mihomoCoreDir(), `${core}${isWin ? '.exe' : ''}`)
 }

--- a/src/main/utils/github.ts
+++ b/src/main/utils/github.ts
@@ -6,7 +6,7 @@ import { createGunzip } from 'zlib'
 import AdmZip from 'adm-zip'
 import { stopCore } from '../core/manager'
 import { getAppConfig } from '../config'
-import { mihomoCoreDir } from './dirs'
+import { mihomoSpecificCoreDir } from './dirs'
 import * as chromeRequest from './chromeRequest'
 import { createLogger } from './logger'
 
@@ -188,7 +188,7 @@ export async function installMihomoCore(version: string): Promise<void> {
     const urlExt = isWin ? 'zip' : 'gz'
     const downloadURL = `https://github.com/MetaCubeX/mihomo/releases/download/${version}/${name}-${version}.${urlExt}`
 
-    const coreDir = mihomoCoreDir()
+    const coreDir = mihomoSpecificCoreDir()
     const tempZip = join(coreDir, `temp-core.${urlExt}`)
     const exeFile = `${name}${isWin ? '.exe' : ''}`
     const targetFile = `mihomo-specific${isWin ? '.exe' : ''}`
@@ -274,8 +274,8 @@ export async function installMihomoCore(version: string): Promise<void> {
     log.info(`Successfully installed mihomo core version ${version}`)
   } catch (error) {
     // 解压失败时下载的压缩包会一直留在内核目录里，每次重试再落一份
-    cleanupTempFile(join(mihomoCoreDir(), `temp-core.zip`))
-    cleanupTempFile(join(mihomoCoreDir(), `temp-core.gz`))
+    cleanupTempFile(join(mihomoSpecificCoreDir(), `temp-core.zip`))
+    cleanupTempFile(join(mihomoSpecificCoreDir(), `temp-core.gz`))
     log.error('Failed to install mihomo core', error)
     throw new Error(
       `Failed to install core: ${error instanceof Error ? error.message : String(error)}`


### PR DESCRIPTION
Four related problems around the core binary's permissions on macOS.

**The manual grant always ran, even when nothing was wrong (#2061, #1744).**
The pkg installer already sets `root:admin` plus the setuid bit
(`build/pkg-scripts/postinstall`), so on a normal install the core is ready before
the app asks for anything. `grantTunPermissions()` ran unconditionally, which
means "manually grant core permission" always popped an authorization prompt, and
several users then get `chown: ...: Operation not permitted` and an error dialog
on a machine where nothing was broken. It now checks first and returns early.

I could not reproduce that `chown` failure on a clean macOS 26.5.2 machine —
both `chown` and `chmod` succeed there on the installed bundle — so it looks
environment dependent rather than universal.

**`&&` made a failing `chown` skip `chmod` (#1532, #495).**
v1.8.9 changed the script to `chown root:admin X && chmod +sx X`. When `chown`
fails the setuid bit is never restored, which matches the reports that 1.8.8
worked and 1.8.9 onwards did not. The script now uses `;` so `chmod` always runs,
and success is decided by re-reading the core's actual permissions instead of by
the osascript exit code.

**Downloaded cores were written into the app bundle (#1269).**
A normal user cannot write there — verified on macOS 26.5.2:
`touch` inside `Contents/Resources/sidecar/` returns `Permission denied`. The
user-selected core now goes to `<userData>/cores`, with a fallback to the old
location so an existing download is not lost. `mihomo-specific` was never in
`ALLOWED_CORES`, so this does not create a setuid binary in a writable directory.

**A helper daemon that fails to load aborted the whole install (#817).**
`launchctl bootstrap` / `load` failures now warn instead of `exit 1`. The other
two failure paths in the same script already only warn, and since v2.0.1 the app
reinstalls and reloads the helper by itself.

Closes #2061
Closes #1269
Refs #1744 #1532 #495 #817