### PR TITLE
fix: stop generated defaults from overwriting profile values

### DIFF
--- a/src/main/core/factory.ts
+++ b/src/main/core/factory.ts
@@ -164,6 +164,12 @@ export async function generateProfile(
   if (!useNameserverPolicy) {
     delete controledMihomoConfig?.dns?.['nameserver-policy']
   }
+  // 空的 TUN 排除地址表示「界面上没有设置」，不能让它覆盖掉配置文件或覆写里已有的
+  // route-exclude-address（与下面清理空 lan-allowed-ips 同理）
+  if (controledMihomoConfig.tun && !controledMihomoConfig.tun['route-exclude-address']?.length) {
+    controledMihomoConfig.tun = { ...controledMihomoConfig.tun }
+    delete controledMihomoConfig.tun['route-exclude-address']
+  }
 
   const profile = deepMerge(currentProfile, controledMihomoConfig)
   // 关闭 DNS 覆写时，如果最终配置没有启用的 DNS 配置，清空 dns-hijack 避免请求被劫持但无法处理

--- a/src/main/core/factory.ts
+++ b/src/main/core/factory.ts
@@ -161,6 +161,12 @@ export async function generateProfile(
   if (!controlSniff) {
     delete controledMihomoConfig.sniffer
   }
+  // 关闭「自定义 hosts」开关时必须不再下发 hosts：内核的 use-hosts 只关掉 DNS 服务的 hosts
+  // 中间件，顶层 hosts 依然会被写进 resolver.DefaultHosts 并在连接解析时命中，
+  // 单靠 use-hosts: false 关不掉
+  if (controledMihomoConfig.dns && !controledMihomoConfig.dns['use-hosts']) {
+    delete controledMihomoConfig.hosts
+  }
   if (!useNameserverPolicy) {
     delete controledMihomoConfig?.dns?.['nameserver-policy']
   }


### PR DESCRIPTION
Two cases where a value from the generated config wins over what the user put in
their profile or override.

**`route-exclude-address` could not be overridden (#704).**
`DEFAULT_MIHOMO_TUN_CONFIG` carries `'route-exclude-address': []`, and the final
`deepMerge` is not in override mode, so arrays are assigned rather than merged —
the empty default replaced whatever the profile had. `exclude-interface` in the
same block works precisely because it has no default. An empty list is now treated
as "not set in the UI" and dropped before merging, the same way the empty
`lan-allowed-ips` is handled just below.

**Turning off custom hosts did not take effect (#433).**
Switching off "custom hosts" only writes `dns.use-hosts: false`. The DNS page omits
the `hosts` key from the patch in that case, and `patchControledMihomoConfig` only
replaces `hosts` when the patch contains it, so the previously saved table stayed
in `mihomo.yaml` and kept being merged in. `use-hosts: false` does not neutralise
it either: mihomo installs the top-level `hosts` map into `resolver.DefaultHosts`
unconditionally (`hub/executor/executor.go`), while `use-hosts` only gates the DNS
server's hosts middleware. The map is now skipped whenever the switch is off. The
entries stay in `mihomo.yaml`, so turning the switch back on restores them.

Note this is a visible behaviour change: anyone who had the switch off but was
relying on the stale table will lose it — which is what the issue asks for.

Closes #704
Closes #433