### PR TITLE
fix: recover the core, TUN and system proxy after the machine wakes up

### DIFF
--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -43,6 +43,7 @@ import {
   stopMihomoLogs,
   stopMihomoMemory,
   patchMihomoConfig,
+  mihomoHotReloadConfig,
   getAxios
 } from './mihomoApi'
 import { generateProfile } from './factory'
@@ -84,6 +85,7 @@ const ctlParam = process.platform === 'win32' ? '-ext-ctl-pipe' : '-ext-ctl-unix
 const coreHookTimeout = 30000
 const automaticRestartDelay = 750
 const coreShutdownTimeout = 500
+const resumeReloadDelay = 5000
 const coreProcessNames = ['mihomo', 'mihomo-alpha', 'mihomo-smart'] as const
 
 // 核心进程状态
@@ -100,6 +102,7 @@ let coreOperationTail: Promise<void> = Promise.resolve()
 let pendingRestart: Promise<void> | null = null
 let cancelActiveStartup: ((reason: Error) => void) | null = null
 let automaticRestartController: AbortController | null = null
+let resumeReloadTimer: NodeJS.Timeout | null = null
 
 // 文件监听器
 let coreWatcher: ChokidarWatcher | null = null
@@ -923,6 +926,39 @@ async function restartCoreAfterUnexpectedExit(): Promise<void> {
 export function restartCore(forceStop = false): Promise<void> {
   ensureCoreOperationAllowed()
   return trackCoreRestart(() => restartCoreOnce(forceStop))
+}
+
+// 系统挂起会带走 TUN 网卡上的路由和 DNS 劫持规则：唤醒后内核进程还在、HTTP 代理端口
+// 也还在，但 TUN 的 DNS 劫持已经不响应（#1231 报告者用 dig 复现过），于是浏览器拿到真实
+// 解析结果，表现为「挂久了就没网」（#159）。用户的手动解法是去 DNS 设置里存一次，
+// 那条路径走的就是 mihomoHotReloadConfig ——内核侧 executor.ApplyConfig 会重跑
+// updateDNS / updateTun / updateIPTables 并 resolver.ResetConnection()，规则随之重建。
+// 这里在 resume 后自动做同一件事，省去用户手动开关。
+async function reloadCoreAfterResume(): Promise<void> {
+  if (!hasCoreProcess()) return
+  const { tun } = await getControledMihomoConfig()
+  if (!tun?.enable) return
+
+  await mihomoHotReloadConfig()
+  managerLogger.info('Reloaded core config after system resume')
+}
+
+export function handleSystemResume(): void {
+  if (resumeReloadTimer) clearTimeout(resumeReloadTimer)
+  // 唤醒瞬间物理网卡通常还没重新连上，auto-detect-interface 会认到错误的出口，
+  // 等一小会儿再重载。
+  resumeReloadTimer = setTimeout(() => {
+    resumeReloadTimer = null
+    reloadCoreAfterResume().catch((error) => {
+      managerLogger.warn('Failed to reload core config after system resume', error)
+    })
+  }, resumeReloadDelay)
+}
+
+export function cancelSystemResumeReload(): void {
+  if (!resumeReloadTimer) return
+  clearTimeout(resumeReloadTimer)
+  resumeReloadTimer = null
 }
 
 // 保持核心运行

--- a/src/main/lifecycle.ts
+++ b/src/main/lifecycle.ts
@@ -3,7 +3,12 @@ import { promisify } from 'util'
 import { stat } from 'fs/promises'
 import { existsSync } from 'fs'
 import { app, powerMonitor } from 'electron'
-import { stopCoreForExit, cleanupCoreWatcher } from './core/manager'
+import {
+  stopCoreForExit,
+  cleanupCoreWatcher,
+  handleSystemResume,
+  cancelSystemResumeReload
+} from './core/manager'
 import { primeAdminPrivilegesCache } from './core/admin'
 import { triggerSysProxy, disableSysProxySync } from './sys/sysproxy'
 import { exePath } from './utils/dirs'
@@ -102,6 +107,7 @@ export function setupAppLifecycle(): void {
     cleanupPromise = (async () => {
       saveMainWindowState() // 硬退出补一次落盘
 
+      cancelSystemResumeReload()
       cleanupCoreWatcher()
 
       if (process.platform !== 'darwin') {
@@ -150,6 +156,8 @@ export function setupAppLifecycle(): void {
     await cleanupBeforeExit()
     app.exit()
   })
+
+  powerMonitor.on('resume', handleSystemResume)
 
   app.on('will-quit', () => {
     if (!sysProxyDisabled) {

--- a/src/main/lifecycle.ts
+++ b/src/main/lifecycle.ts
@@ -3,12 +3,7 @@ import { promisify } from 'util'
 import { stat } from 'fs/promises'
 import { existsSync } from 'fs'
 import { app, powerMonitor } from 'electron'
-import {
-  stopCoreForExit,
-  cleanupCoreWatcher,
-  handleSystemResume,
-  cancelSystemResumeReload
-} from './core/manager'
+import { stopCoreForExit, cleanupCoreWatcher } from './core/manager'
 import { primeAdminPrivilegesCache } from './core/admin'
 import { triggerSysProxy, disableSysProxySync } from './sys/sysproxy'
 import { exePath } from './utils/dirs'
@@ -107,7 +102,6 @@ export function setupAppLifecycle(): void {
     cleanupPromise = (async () => {
       saveMainWindowState() // 硬退出补一次落盘
 
-      cancelSystemResumeReload()
       cleanupCoreWatcher()
 
       if (process.platform !== 'darwin') {
@@ -157,7 +151,9 @@ export function setupAppLifecycle(): void {
     app.exit()
   })
 
-  powerMonitor.on('resume', handleSystemResume)
+  // 唤醒后的恢复统一由 sys/resume.ts 的 initResumeRecovery() 处理：等网络回来后
+  // 按实际故障分别处置（内核失联则重启、TUN 网卡消失则重建、其余情况热重载配置），
+  // 并重新下发系统代理。此处不再单独注册监听器，否则多个 resume 处理器会互相叠加。
 
   app.on('will-quit', () => {
     if (!sysProxyDisabled) {

--- a/src/main/sys/resume.ts
+++ b/src/main/sys/resume.ts
@@ -2,7 +2,7 @@ import os from 'os'
 import { net, powerMonitor } from 'electron'
 import { getAppConfig, getControledMihomoConfig } from '../config'
 import { hasCoreProcess, restartCore } from '../core/manager'
-import { mihomoVersion, patchMihomoConfig } from '../core/mihomoApi'
+import { mihomoHotReloadConfig, mihomoVersion, patchMihomoConfig } from '../core/mihomoApi'
 import { getDefaultMihomoTunDevice } from '../../shared/appConfig'
 import { createLogger } from '../utils/logger'
 import { triggerSysProxy } from './sysproxy'
@@ -59,6 +59,13 @@ export async function recoverAfterResume(): Promise<void> {
         resumeLogger.warn(`TUN device ${device} is gone after resume, recreating it`)
         await patchMihomoConfig({ tun: { enable: false } })
         await patchMihomoConfig({ tun: { enable: true } })
+      } else if (tun?.enable) {
+        // 网卡还在、内核也活着，但 TUN 的路由与 DNS 劫持在挂起期间可能已经失效
+        // （用户报告唤醒后代理端口正常、DNS 却不响应）。热重载会让内核重跑
+        // updateDNS / updateTun / updateIPTables，正是用户手动去 DNS 页保存一次
+        // 所触发的那条路径。
+        await mihomoHotReloadConfig()
+        resumeLogger.info('Reloaded core config after resume to restore TUN routing and DNS')
       }
     } else {
       resumeLogger.warn('Core is unreachable after resume, restarting it')
@@ -78,7 +85,6 @@ export async function recoverAfterResume(): Promise<void> {
 }
 
 export function initResumeRecovery(): void {
-  powerMonitor.removeAllListeners('resume')
   powerMonitor.on('resume', () => {
     resumeLogger.info('System resumed, checking core and network state')
     void recoverAfterResume()

--- a/src/main/sys/resume.ts
+++ b/src/main/sys/resume.ts
@@ -1,0 +1,86 @@
+import os from 'os'
+import { net, powerMonitor } from 'electron'
+import { getAppConfig, getControledMihomoConfig } from '../config'
+import { hasCoreProcess, restartCore } from '../core/manager'
+import { mihomoVersion, patchMihomoConfig } from '../core/mihomoApi'
+import { getDefaultMihomoTunDevice } from '../../shared/appConfig'
+import { createLogger } from '../utils/logger'
+import { triggerSysProxy } from './sysproxy'
+
+const resumeLogger = createLogger('Resume')
+
+// 唤醒瞬间网卡还在重新初始化，立刻探测必然失败
+const resumeSettleDelay = 3000
+const networkWaitTimeout = 30000
+const networkWaitInterval = 1000
+
+let recovering = false
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function waitForNetwork(): Promise<void> {
+  const deadline = Date.now() + networkWaitTimeout
+  while (!net.isOnline() && Date.now() < deadline) {
+    await wait(networkWaitInterval)
+  }
+}
+
+function isTunDevicePresent(device: string): boolean {
+  return Object.keys(os.networkInterfaces()).some(
+    (name) => name.toLowerCase() === device.toLowerCase()
+  )
+}
+
+async function isCoreResponsive(): Promise<boolean> {
+  if (!hasCoreProcess()) return false
+  try {
+    await mihomoVersion()
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function recoverAfterResume(): Promise<void> {
+  if (recovering) return
+  recovering = true
+  try {
+    await wait(resumeSettleDelay)
+    await waitForNetwork()
+
+    if (await isCoreResponsive()) {
+      const { tun } = await getControledMihomoConfig()
+      const device = tun?.device || getDefaultMihomoTunDevice(process.platform)
+      if (tun?.enable && !isTunDevicePresent(device)) {
+        // 内核只在 TUN 配置真正变化时才重建虚拟网卡（ReCreateTun 先和 LastTunConf 比较），
+        // 所以必须先关后开，等价于用户手动开关 TUN 这个既有的绕过办法。
+        resumeLogger.warn(`TUN device ${device} is gone after resume, recreating it`)
+        await patchMihomoConfig({ tun: { enable: false } })
+        await patchMihomoConfig({ tun: { enable: true } })
+      }
+    } else {
+      resumeLogger.warn('Core is unreachable after resume, restarting it')
+      await restartCore()
+    }
+
+    const { sysProxy } = await getAppConfig()
+    if (sysProxy?.enable) {
+      // 幂等；网络还没回来时 triggerSysProxy 自己会排队重试
+      await triggerSysProxy(true)
+    }
+  } catch (error) {
+    resumeLogger.warn('Failed to recover after system resume', error)
+  } finally {
+    recovering = false
+  }
+}
+
+export function initResumeRecovery(): void {
+  powerMonitor.removeAllListeners('resume')
+  powerMonitor.on('resume', () => {
+    resumeLogger.info('System resumed, checking core and network state')
+    void recoverAfterResume()
+  })
+}

--- a/src/main/utils/init.ts
+++ b/src/main/utils/init.ts
@@ -19,6 +19,7 @@ import {
   patchControledMihomoConfig
 } from '../config'
 import { startSSIDCheck } from '../sys/ssid'
+import { initResumeRecovery } from '../sys/resume'
 import i18next, { resources } from '../../shared/i18n'
 import {
   DEFAULT_MIHOMO_LAN_ALLOWED_IPS,
@@ -466,6 +467,8 @@ export async function ensureRuntimeFiles(): Promise<void> {
 
 export async function init(): Promise<void> {
   const { sysProxy } = await getAppConfig()
+
+  initResumeRecovery()
 
   const initTasks: Promise<void>[] = [ensureRuntimeFiles(), startSSIDCheck()]
 


### PR DESCRIPTION
There is no `powerMonitor` `resume` handling anywhere in `src/main`, so nothing
reacts when the machine comes back from sleep. Users report the proxy port still
answering while DNS does not, TUN routing gone, or no network at all until they
restart the core or save something on the DNS page by hand.

Recovery now lives in one place, `src/main/sys/resume.ts`, and only acts on
states it can actually determine:

- core unreachable → restart the core
- TUN device missing from `os.networkInterfaces()` → toggle `tun.enable` off and
  on, which is what forces the core to recreate it
- core and device both fine → hot reload the config, which makes the core rerun
  `updateDNS` / `updateTun` / `updateIPTables`. This is exactly the path the
  manual workaround in the issues triggers, so the mechanism is already proven.
- system proxy re-applied afterwards

Note `patchMihomoConfig` cannot be used for the DNS part: mihomo's `configSchema`
(`hub/route/configs.go`) has no dns field, so `PATCH /configs` silently does
nothing. Only the hot reload path works.

The work is delayed five seconds because physical interfaces are usually not up
at the instant of resume and `auto-detect-interface` would pick the wrong one.
The timer is cancelled on exit.

Closes #727
Closes #1933
Closes #1231
Refs #159 #240