### PR TITLE
fix: keep the system proxy usable in lightweight mode and while offline

### DIFF
--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -939,10 +939,27 @@ export async function keepCoreAlive(): Promise<boolean> {
   }
 }
 
+// PAC 脚本由主进程内的 HTTP 服务提供，轻量模式下主进程退出后该服务随之消失，
+// 而系统代理仍指向已经失效的 PAC URL，结果就是一进轻量模式就断网。
+// 退出前把系统代理改写成等价的手动代理，直接指向仍在后台运行的内核端口。
+// 下次正常启动时 init() 会按配置里的 auto 模式重新拉起 PAC 服务并写回 PAC 地址。
+async function keepSysProxyUsableWithoutMainProcess(): Promise<void> {
+  try {
+    const { sysProxy } = await getAppConfig()
+    if (!sysProxy?.enable || (sysProxy.mode ?? 'manual') !== 'auto') return
+    const { triggerSysProxy } = await import('../sys/sysproxy')
+    await triggerSysProxy(true, { force: true, forceManual: true })
+    managerLogger.info('Rewrote PAC system proxy to manual before entering lightweight mode')
+  } catch (error) {
+    managerLogger.warn('Failed to rewrite PAC system proxy before lightweight mode', error)
+  }
+}
+
 // 退出但保持核心运行
 export async function quitWithoutCore(): Promise<void> {
   managerLogger.info(`Starting lightweight mode on platform: ${process.platform}`)
   if (!(await keepCoreAlive())) return
+  await keepSysProxyUsableWithoutMainProcess()
   await startMonitor(true)
   managerLogger.info('Exiting main process, core will continue running in background')
   app.exit()

--- a/src/main/sys/sysproxy.ts
+++ b/src/main/sys/sysproxy.ts
@@ -66,6 +66,9 @@ const defaultBypass: string[] = (() => {
 interface TriggerSysProxyOptions {
   helperTimeout?: number
   force?: boolean
+  // PAC 脚本由主进程内的 HTTP 服务提供，主进程退出后该服务就消失了。
+  // 需要在没有主进程的情况下继续代理时，用等价的手动代理替代 PAC。
+  forceManual?: boolean
 }
 
 function helperAxiosOptions(helperTimeout?: number): { socketPath: string; timeout?: number } {
@@ -89,7 +92,7 @@ export async function triggerSysProxy(
     if (net.isOnline() || options.force) {
       if (enable) {
         await disableSysProxy(options.helperTimeout)
-        await enableSysProxy(options.helperTimeout)
+        await enableSysProxy(options.helperTimeout, options.forceManual)
       } else {
         await disableSysProxy(options.helperTimeout)
       }
@@ -110,10 +113,15 @@ export async function triggerSysProxy(
   return operation
 }
 
-async function enableSysProxy(helperTimeout?: number): Promise<void> {
-  await startPacServer()
+async function enableSysProxy(helperTimeout?: number, forceManual = false): Promise<void> {
+  if (forceManual) {
+    await stopPacServer()
+  } else {
+    await startPacServer()
+  }
   const { sysProxy } = await getAppConfig()
   const { mode, host, bypass = defaultBypass } = sysProxy
+  const effectiveMode = forceManual ? 'manual' : mode
   const { 'mixed-port': port = DEFAULT_MIHOMO_PORTS.mixed } = await getControledMihomoConfig()
   const proxyHost = host || '127.0.0.1'
   const formattedBypass = bypass
@@ -123,7 +131,7 @@ async function enableSysProxy(helperTimeout?: number): Promise<void> {
 
   if (process.platform === 'darwin') {
     // macOS 需要 helper 提权
-    if (mode === 'auto') {
+    if (effectiveMode === 'auto') {
       await helperRequest(() =>
         axios.post(
           'http://localhost/pac',
@@ -143,7 +151,7 @@ async function enableSysProxy(helperTimeout?: number): Promise<void> {
   } else {
     // Windows / Linux 直接使用 sysproxy-rs
     try {
-      if (mode === 'auto') {
+      if (effectiveMode === 'auto') {
         triggerAutoProxy(true, `http://${proxyHost}:${pacPort}/pac`)
       } else {
         triggerManualProxy(true, proxyHost, port, formattedBypass)

--- a/src/main/sys/sysproxy.ts
+++ b/src/main/sys/sysproxy.ts
@@ -89,7 +89,9 @@ export async function triggerSysProxy(
   }
 
   const operation = triggerSysProxyQueue.then(async () => {
-    if (net.isOnline() || options.force) {
+    // 关闭系统代理是纯本地操作，不需要联网。离线时推迟只会把用户继续困在一个
+    // 已经无法工作的代理后面，正是他最想关掉它的时候。
+    if (!enable || net.isOnline() || options.force) {
       if (enable) {
         await disableSysProxy(options.helperTimeout)
         await enableSysProxy(options.helperTimeout, options.forceManual)


### PR DESCRIPTION
**Lightweight mode cut off the network for PAC users (#1016, #1011).**
The PAC script is served by an HTTP server inside the main process
(`startPacServer`). `quitWithoutCore` calls `app.exit()`, which kills that server
while the system proxy still points at the now dead PAC URL. Before exiting, the
system proxy is now rewritten to the equivalent manual proxy — same host, the
mixed port, same bypass list. `sysProxy.mode` is left untouched so the next normal
start restores PAC.

This does change behaviour for anyone using a complex custom PAC: after entering
lightweight mode everything goes through the mixed port plus the bypass list
rather than through their script. For the default PAC the two are equivalent, and
the alternative today is no network at all.

**The system proxy could not be turned off while offline (#209).**
`triggerSysProxy` gated the whole operation behind `net.isOnline()`. Turning the
proxy *off* is a purely local write that needs no network, but it was pushed into
a five second retry loop, leaving the user stuck behind a proxy that no longer
works. Only enabling checks connectivity now.

Closes #1016
Closes #1011
Refs #209