### PR TITLE
fix: surface core startup and TUN failures instead of hiding them

### DIFF
--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -842,23 +842,29 @@ async function stopCoreInternal(force = false, cancelStartup = true): Promise<vo
   await cleanupStoppedCoreResources()
 }
 
-function stopCoreProcessAndStreams(cancelStartup = true): void {
+function stopCoreProcessAndStreams(
+  cancelStartup = true,
+  keepWatchdog = false
+): ChildProcess | null {
   if (cancelStartup) {
     cancelActiveStartup?.(new Error('Core startup was cancelled by a stop request'))
     cancelActiveStartup = null
   }
+  const stoppedChild = child
   if (child) {
     child.removeAllListeners()
     child.kill('SIGINT')
     child = null
   }
 
-  stopCoreProcessWatchdog()
+  if (!keepWatchdog) stopCoreProcessWatchdog()
 
   stopMihomoTraffic()
   stopMihomoConnections()
   stopMihomoLogs()
   stopMihomoMemory()
+
+  return stoppedChild
 }
 
 async function cleanupStoppedCoreResources(): Promise<void> {
@@ -879,13 +885,19 @@ export async function stopCore(force = false): Promise<void> {
 }
 
 // 退出不排队等待启动/重启完成：先同步终止子进程，再做有界清理。
+// SIGINT 之后必须确认核心真的退出：core.pid 只在轻量模式写入，普通运行时
+// stopPidFileCore 是空操作，没有任何 SIGKILL 兜底。核心若在退出预算内没走完
+// （例如 TUN 拆除慢），主进程 app.exit() 后它就成了孤儿进程。
+// Linux watchdog 也要留到确认退出之后再撤，否则最后一道兜底先于核心消失。
 export async function stopCoreForExit(): Promise<void> {
   coreOperationPhase = 'shutting-down'
   cancelAutomaticRestart()
-  stopCoreProcessAndStreams()
+  const stoppedChild = stopCoreProcessAndStreams(true, true)
   await Promise.allSettled([
     recoverDNS({ force: true, timeout: 750 }),
-    cleanupStoppedCoreResources()
+    cleanupStoppedCoreResources(),
+    // 确认退出后才撤 watchdog；确认失败时留着它，让它在主进程退出时补 kill -9。
+    ensureCoreProcessExited(stoppedChild).then(() => stopCoreProcessWatchdog(stoppedChild?.pid))
   ])
 }
 

--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -995,7 +995,15 @@ export async function checkProfileConfig(
 
       if (errorLines.length === 0) {
         const allLines = stdout.split('\n').filter((line) => line.trim().length > 0)
-        throw new Error(`${i18next.t('mihomo.error.profileCheckFailed')}:\n${allLines.join('\n')}`)
+        // 内核根本没能启动时（动态链接失败、缺符号、架构不匹配）只有 stderr 有内容，
+        // stdout 为空，此前拼出来的是一句没有任何原因的“配置检查失败”。
+        const detailLines =
+          allLines.length > 0
+            ? allLines
+            : (stderr ?? '').split('\n').filter((line) => line.trim().length > 0)
+        throw new Error(
+          `${i18next.t('mihomo.error.profileCheckFailed')}:\n${detailLines.join('\n')}`
+        )
       } else {
         throw new Error(
           `${i18next.t('mihomo.error.profileCheckFailed')}:\n${errorLines.join('\n')}`

--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -7,7 +7,7 @@ import path from 'path'
 import os from 'os'
 import { existsSync, watch, type FSWatcher as NodeFSWatcher } from 'fs'
 import chokidar, { type FSWatcher as ChokidarWatcher } from 'chokidar'
-import { app, ipcMain } from 'electron'
+import { app, dialog, ipcMain } from 'electron'
 import { mainWindow } from '../window'
 import {
   getAppConfig,
@@ -84,6 +84,8 @@ const ctlParam = process.platform === 'win32' ? '-ext-ctl-pipe' : '-ext-ctl-unix
 const coreHookTimeout = 30000
 const automaticRestartDelay = 750
 const coreShutdownTimeout = 500
+// 同一次失败内核可能连打多行，10 秒内只提示一次，避免弹窗刷屏
+const tunFailureReportInterval = 10000
 const coreProcessNames = ['mihomo', 'mihomo-alpha', 'mihomo-smart'] as const
 
 // 核心进程状态
@@ -644,15 +646,46 @@ function setupCoreListeners(
     }
   })
 
+  let lastTunFailureAt = 0
+
   proc.stdout?.on('data', async (data) => {
     const str = data.toString()
 
     // TUN 权限错误
     if (str.includes('configure tun interface: operation not permitted')) {
+      lastTunFailureAt = Date.now()
       patchControledMihomoConfig({ tun: { enable: false } })
       mainWindow?.webContents.send('controledMihomoConfigUpdated')
       ipcMain.emit('updateTrayMenu')
       rejectStartup(i18next.t('tun.error.tunPermissionDenied'))
+      return
+    }
+
+    // 其它虚拟网卡创建失败：内核只打印 "Start TUN listening error" 并在 ReCreateTun 的 defer 里
+    // 把 tun.enable 置回 false，自身继续运行，界面却仍显示虚拟网卡已开启，
+    // 用户只能看到"开了没效果"。把内核原始错误反馈出来，并同步关掉开关。
+    const tunListenErrorLine = str
+      .split('\n')
+      .find((line: string) => line.includes('Start TUN listening error'))
+    if (tunListenErrorLine && Date.now() - lastTunFailureAt > tunFailureReportInterval) {
+      lastTunFailureAt = Date.now()
+      managerLogger.error('TUN listening error detected:', tunListenErrorLine.trim())
+      try {
+        await patchControledMihomoConfig({ tun: { enable: false } })
+      } catch (error) {
+        managerLogger.warn('Failed to disable TUN after listening error', error)
+      }
+      mainWindow?.webContents.send('controledMihomoConfigUpdated')
+      ipcMain.emit('updateTrayMenu')
+      // 不能用 showErrorBox/showMessageBoxSync：模态框会卡住主进程，内核 stdout 写满后会一起卡死
+      dialog
+        .showMessageBox({
+          type: 'error',
+          title: i18next.t('tun.error.tunStartFailed'),
+          message: i18next.t('tun.error.tunStartFailed'),
+          detail: tunListenErrorLine.trim()
+        })
+        .catch(() => {})
       return
     }
 

--- a/src/renderer/src/locales/en-US.json
+++ b/src/renderer/src/locales/en-US.json
@@ -509,6 +509,7 @@
   "tun.excludeAddress.notSaved": "The exclude list won't be saved while it contains invalid networks — fix or remove them first.",
   "tun.notifications.coreAuthSuccess": "Core Authorization Successful",
   "tun.notifications.firewallResetSuccess": "Firewall Reset Successful",
+  "tun.error.tunStartFailed": "Failed to start the TUN interface, it has been turned off",
   "tun.permissions.title": "Administrator Privileges Required",
   "tun.permissions.message": "TUN mode requires administrator privileges. Restart the application now to get permissions?",
   "tun.permissions.failed": "Permission authorization failed",

--- a/src/renderer/src/locales/en-US.json
+++ b/src/renderer/src/locales/en-US.json
@@ -509,6 +509,7 @@
   "tun.excludeAddress.notSaved": "The exclude list won't be saved while it contains invalid networks — fix or remove them first.",
   "tun.notifications.coreAuthSuccess": "Core Authorization Successful",
   "tun.notifications.firewallResetSuccess": "Firewall Reset Successful",
+  "tun.error.tunPermissionDenied": "Failed to start the TUN interface, try granting the core permissions manually",
   "tun.error.tunStartFailed": "Failed to start the TUN interface, it has been turned off",
   "tun.permissions.title": "Administrator Privileges Required",
   "tun.permissions.message": "TUN mode requires administrator privileges. Restart the application now to get permissions?",

--- a/src/renderer/src/locales/fa-IR.json
+++ b/src/renderer/src/locales/fa-IR.json
@@ -499,6 +499,7 @@
   "tun.notifications.coreAuthSuccess": "مجوزدهی به هسته با موفقیت انجام شد",
   "tun.notifications.firewallResetSuccess": "بازنشانی دیوار آتش با موفقیت انجام شد",
   "tun.error.tunPermissionDenied": "راه‌اندازی رابط TUN با شکست مواجه شد، لطفا به صورت دستی به هسته مجوز دهید",
+  "tun.error.tunStartFailed": "راه‌اندازی رابط TUN ناموفق بود و خاموش شد",
   "dns.title": "تنظیمات DNS",
   "dns.enable": "فعال‌سازی DNS",
   "dns.enhancedMode.title": "حالت نگاشت دامنه",

--- a/src/renderer/src/locales/ru-RU.json
+++ b/src/renderer/src/locales/ru-RU.json
@@ -501,6 +501,7 @@
   "tun.notifications.coreAuthSuccess": "Авторизация ядра успешна",
   "tun.notifications.firewallResetSuccess": "Брандмауэр успешно сброшен",
   "tun.error.tunPermissionDenied": "Ошибка запуска TUN, попробуйте вручную предоставить разрешения ядру",
+  "tun.error.tunStartFailed": "Не удалось запустить интерфейс TUN, он был отключён",
   "dns.title": "Настройки DNS",
   "dns.enable": "Включить DNS",
   "dns.enhancedMode.title": "Режим маппинга доменов",

--- a/src/renderer/src/locales/zh-CN.json
+++ b/src/renderer/src/locales/zh-CN.json
@@ -509,6 +509,7 @@
   "tun.excludeAddress.notSaved": "含有无效网段时该排除列表不会被保存，请先修正或删除。",
   "tun.notifications.coreAuthSuccess": "内核授权成功",
   "tun.notifications.firewallResetSuccess": "防火墙重设成功",
+  "tun.error.tunPermissionDenied": "虚拟网卡启动失败，请尝试手动授权内核",
   "tun.error.tunStartFailed": "虚拟网卡启动失败，已自动关闭",
   "tun.permissions.title": "需要管理员权限",
   "tun.permissions.message": "启用 TUN 模式需要管理员权限，是否现在重启应用获取权限？",

--- a/src/renderer/src/locales/zh-CN.json
+++ b/src/renderer/src/locales/zh-CN.json
@@ -509,6 +509,7 @@
   "tun.excludeAddress.notSaved": "含有无效网段时该排除列表不会被保存，请先修正或删除。",
   "tun.notifications.coreAuthSuccess": "内核授权成功",
   "tun.notifications.firewallResetSuccess": "防火墙重设成功",
+  "tun.error.tunStartFailed": "虚拟网卡启动失败，已自动关闭",
   "tun.permissions.title": "需要管理员权限",
   "tun.permissions.message": "启用 TUN 模式需要管理员权限，是否现在重启应用获取权限？",
   "tun.permissions.failed": "权限授权失败",

--- a/src/renderer/src/locales/zh-TW.json
+++ b/src/renderer/src/locales/zh-TW.json
@@ -509,6 +509,7 @@
   "tun.excludeAddress.notSaved": "含有無效網段時該排除列表不會被儲存，請先修正或刪除。",
   "tun.notifications.coreAuthSuccess": "內核授權成功",
   "tun.notifications.firewallResetSuccess": "防火牆重設成功",
+  "tun.error.tunStartFailed": "虛擬網卡啟動失敗，已自動關閉",
   "tun.permissions.title": "需要系統管理員權限",
   "tun.permissions.message": "啟用 TUN 模式需要系統管理員權限，是否現在重啟應用獲取權限？",
   "tun.permissions.failed": "權限授權失敗",

--- a/src/renderer/src/locales/zh-TW.json
+++ b/src/renderer/src/locales/zh-TW.json
@@ -509,6 +509,7 @@
   "tun.excludeAddress.notSaved": "含有無效網段時該排除列表不會被儲存，請先修正或刪除。",
   "tun.notifications.coreAuthSuccess": "內核授權成功",
   "tun.notifications.firewallResetSuccess": "防火牆重設成功",
+  "tun.error.tunPermissionDenied": "虛擬網卡啟動失敗，請嘗試手動授權核心",
   "tun.error.tunStartFailed": "虛擬網卡啟動失敗，已自動關閉",
   "tun.permissions.title": "需要系統管理員權限",
   "tun.permissions.message": "啟用 TUN 模式需要系統管理員權限，是否現在重啟應用獲取權限？",


### PR DESCRIPTION
**"Profile check failed" with nothing after the colon (#1404 and friends).**
`checkProfileConfig` built its error message from stdout only. When the core
cannot start it writes to stderr and leaves stdout empty, so the user got a bare
"profile check failed". The logs in #1132 show it exactly: `Profile check stdout`
is empty and the dyld error is on stderr. It now falls back to stderr when stdout
has nothing usable.

**A TUN device that failed to appear was reported as success (#453).**
When the core cannot create the adapter it logs `Start TUN listening error` and
carries on with `tunConf.Enable` reset to false. The GUI only matched the
permission error and swallowed everything else, so the switch stayed on and the
tray still showed TUN while nothing was actually tunnelled. The failure is now
shown, using an async `showMessageBox` — a modal box blocks the main process, and
once the core's stdout pipe fills up that deadlocks the core too.

**Missing translation for the TUN permission error (#655).**
`tun.error.tunPermissionDenied` only existed in ru-RU and fa-IR. en-US was missing
too, so the fallback chain broke and Chinese and English users saw the raw key in
the dialog. Added for zh-CN, en-US and zh-TW.

**The core could outlive the app on Linux (#1341).**
`stopCoreForExit()` sent SIGINT and then immediately stopped the Linux watchdog,
while `lifecycle.ts` waits at most 1.2 s before `app.exit()`. There is no SIGKILL
fallback on that path: `stopPidFileCore()` reads `dataDir()/core.pid`, which is
only written by lightweight mode. So if the core needed longer than the budget —
tearing down TUN, for instance — it was orphaned, and the one thing that could
have reaped it had already been stopped. The watchdog is now kept until
`ensureCoreProcessExited()` confirms the core is gone; if that cannot be
confirmed the watchdog stays so it can `kill -9` when the main process exits. The
PID-reuse guard added in 196fdcb is unchanged.

Closes #453
Closes #655
Closes #1341
Refs #1404 #1132