### PR TITLE
fix: a batch of small UI, tray, floating window and file handling bugs

### DIFF
--- a/src/main/resolve/backup.ts
+++ b/src/main/resolve/backup.ts
@@ -50,7 +50,7 @@ function getWebDAVBackupPrefix(): string {
 }
 
 async function getWebDAVClient(): Promise<WebDAVContext> {
-  const { createClient } = await import('webdav/dist/node/index.js')
+  const { createClient, AuthType } = await import('webdav/dist/node/index.js')
   const {
     webdavUrl = '',
     webdavUsername = '',
@@ -60,10 +60,18 @@ async function getWebDAVClient(): Promise<WebDAVContext> {
     webdavIgnoreCert = false
   } = await getAppConfig()
 
-  const clientOptions: Parameters<typeof createClient>[1] = {
-    username: webdavUsername,
-    password: webdavPassword
-  }
+  // webdav 自带的 Basic 认证走 base-64 包，只接受 Latin1 字符，非 ASCII 用户名/密码
+  // 会直接抛 InvalidCharacterError（#323）。按 RFC 7617 先用 UTF-8 编码再 base64，
+  // 自己拼 Authorization 头，并关掉库内的认证以免被覆盖。
+  const clientOptions: Parameters<typeof createClient>[1] =
+    webdavUsername || webdavPassword
+      ? {
+          authType: AuthType.None,
+          headers: {
+            Authorization: `Basic ${Buffer.from(`${webdavUsername}:${webdavPassword}`, 'utf-8').toString('base64')}`
+          }
+        }
+      : {}
 
   if (webdavIgnoreCert) {
     clientOptions.httpsAgent = new https.Agent({

--- a/src/main/resolve/floatingWindow.ts
+++ b/src/main/resolve/floatingWindow.ts
@@ -66,6 +66,7 @@ async function createFloatingWindow(): Promise<void> {
       if (!win.isDestroyed()) {
         win.destroy()
       }
+      void restoreTrayIcon()
     })
 
     // 窗口销毁后必须清掉引用，否则 isVisible() 之类的调用会作用在已销毁窗口上抛错；
@@ -111,6 +112,17 @@ async function createFloatingWindow(): Promise<void> {
   }
 }
 
+// 只有在悬浮窗顶上时才允许关掉托盘图标（见 general-config.tsx）。悬浮窗一旦没了，
+// 必须把托盘找回来：否则主窗口一关就再没有任何入口，用户只能去任务管理器杀进程（#2046）。
+async function restoreTrayIcon(): Promise<void> {
+  try {
+    await showTrayIcon()
+    await patchAppConfig({ disableTray: false })
+  } catch (error) {
+    logError('Failed to restore tray icon', error)
+  }
+}
+
 export async function showFloatingWindow(): Promise<void> {
   try {
     if (floatingWindow && !floatingWindow.isDestroyed()) {
@@ -128,6 +140,8 @@ export async function showFloatingWindow(): Promise<void> {
     } else {
       await patchAppConfig({ floatingWindowCompatMode: true })
     }
+    // 这次没建起来，本次会话就没有悬浮窗可用了
+    await restoreTrayIcon()
     throw error
   }
 }
@@ -148,8 +162,7 @@ export async function closeFloatingWindow(): Promise<void> {
     floatingWindow.destroy()
     floatingWindow = null
   }
-  await showTrayIcon()
-  await patchAppConfig({ disableTray: false })
+  await restoreTrayIcon()
 }
 
 export async function showContextMenu(): Promise<void> {

--- a/src/main/resolve/floatingWindow.ts
+++ b/src/main/resolve/floatingWindow.ts
@@ -1,6 +1,7 @@
 import { join } from 'path'
+import { readFileSync } from 'fs'
 import { is } from '@electron-toolkit/utils'
-import { BrowserWindow, ipcMain } from 'electron'
+import { app, BrowserWindow, ipcMain, screen } from 'electron'
 import windowStateKeeper from 'electron-window-state'
 import { getAppConfig, patchAppConfig } from '../config'
 import { floatingWindowLogger } from '../utils/logger'
@@ -9,13 +10,49 @@ import { buildContextMenu, showTrayIcon } from './tray'
 
 export let floatingWindow: BrowserWindow | null = null
 
+const FLOATING_WINDOW_STATE_FILE = 'floating-window-state.json'
+const FLOATING_WINDOW_WIDTH = 135
+const FLOATING_WINDOW_HEIGHT = 42
+
 function logError(message: string, error?: unknown): void {
   floatingWindowLogger.log(`FloatingWindow Error: ${message}`, error).catch(() => {})
 }
 
+// electron-window-state 只在窗口**完整**落在某个显示器内时才恢复坐标，否则整个重置为 (0, 0)。
+// 悬浮窗常被拖到屏幕边缘只露出一部分，于是下次启动就跑到左上角。这里自己读一次状态文件，
+// 把上次的位置夹回最近显示器的工作区，位置本来就合法时结果与原来完全一致。
+function restoreFloatingWindowPosition(): { x?: number; y?: number } {
+  let saved: { x?: unknown; y?: unknown }
+  try {
+    saved = JSON.parse(
+      readFileSync(join(app.getPath('userData'), FLOATING_WINDOW_STATE_FILE), 'utf-8')
+    )
+  } catch {
+    return {}
+  }
+
+  const { x, y } = saved
+  if (!Number.isInteger(x) || !Number.isInteger(y)) return {}
+
+  const { workArea } = screen.getDisplayMatching({
+    x: x as number,
+    y: y as number,
+    width: FLOATING_WINDOW_WIDTH,
+    height: FLOATING_WINDOW_HEIGHT
+  })
+  const maxX = Math.max(workArea.x, workArea.x + workArea.width - FLOATING_WINDOW_WIDTH)
+  const maxY = Math.max(workArea.y, workArea.y + workArea.height - FLOATING_WINDOW_HEIGHT)
+
+  return {
+    x: Math.min(Math.max(x as number, workArea.x), maxX),
+    y: Math.min(Math.max(y as number, workArea.y), maxY)
+  }
+}
+
 async function createFloatingWindow(): Promise<void> {
   try {
-    const floatingWindowState = windowStateKeeper({ file: 'floating-window-state.json' })
+    const restoredPosition = restoreFloatingWindowPosition()
+    const floatingWindowState = windowStateKeeper({ file: FLOATING_WINDOW_STATE_FILE })
     const { customTheme = 'default.css', floatingWindowCompatMode = true } = await getAppConfig()
 
     const safeMode = process.env.FLOATING_SAFE_MODE === 'true'
@@ -23,10 +60,10 @@ async function createFloatingWindow(): Promise<void> {
       floatingWindowCompatMode || process.env.FLOATING_COMPAT_MODE === 'true' || safeMode
 
     const windowOptions: Electron.BrowserWindowConstructorOptions = {
-      width: 135,
-      height: 42,
-      x: floatingWindowState.x,
-      y: floatingWindowState.y,
+      width: FLOATING_WINDOW_WIDTH,
+      height: FLOATING_WINDOW_HEIGHT,
+      x: restoredPosition.x,
+      y: restoredPosition.y,
       show: false,
       frame: safeMode,
       alwaysOnTop: !safeMode,

--- a/src/main/resolve/tray.ts
+++ b/src/main/resolve/tray.ts
@@ -547,16 +547,49 @@ export async function closeTrayIcon(): Promise<void> {
   trayMenu = null
 }
 
+// macOS 的 Dock 图标显隐都是异步生效的，而且 Electron 的 Browser::DockHide 会在上一次 DockShow
+// 之后 1 秒内直接 return（规避 TransformProcessType 留下多个 Dock 图标的系统 bug）。
+// 快速点击托盘时 show/hide 交替出现，hide 被静默丢弃，Dock 图标就留在原地不再隐藏（#1867）。
+// 这里把显隐串行化，并在 Electron 的抑制窗口内推迟 hide，同时用期望状态做合并，避免过期操作生效。
+const DOCK_HIDE_SUPPRESSION = 1100
+let dockIconChain: Promise<void> = Promise.resolve()
+let desiredDockVisible: boolean | null = null
+let lastDockShowAt = 0
+
+function setDockIconVisible(visible: boolean): Promise<void> {
+  const dock = app.dock
+  if (process.platform !== 'darwin' || !dock) return Promise.resolve()
+
+  desiredDockVisible = visible
+  dockIconChain = dockIconChain
+    .then(async () => {
+      // 排队期间期望状态被改写，说明这次操作已经过期
+      if (desiredDockVisible !== visible) return
+      if (visible) {
+        if (dock.isVisible()) return
+        lastDockShowAt = Date.now()
+        await dock.show()
+        return
+      }
+      const suppressed = DOCK_HIDE_SUPPRESSION - (Date.now() - lastDockShowAt)
+      if (suppressed > 0) {
+        await new Promise((resolve) => setTimeout(resolve, suppressed))
+        if (desiredDockVisible !== visible) return
+      }
+      // 不能用 isVisible() 提前返回：hide 被抑制时激活策略仍是 regular，必须真的再调一次
+      dock.hide()
+    })
+    .catch(() => {})
+
+  return dockIconChain
+}
+
 export async function showDockIcon(): Promise<void> {
-  if (process.platform === 'darwin' && app.dock && !app.dock.isVisible()) {
-    await app.dock.show()
-  }
+  await setDockIconVisible(true)
 }
 
 export async function hideDockIcon(): Promise<void> {
-  if (process.platform === 'darwin' && app.dock && app.dock.isVisible()) {
-    app.dock.hide()
-  }
+  await setDockIconVisible(false)
 }
 
 const getIconPaths = (): Record<TrayIconStatus, string> => {

--- a/src/main/resolve/tray.ts
+++ b/src/main/resolve/tray.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'child_process'
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { extname, join } from 'path'
-import { app, ipcMain, Menu, nativeImage, shell, Tray } from 'electron'
+import { app, ipcMain, Menu, nativeImage, shell, systemPreferences, Tray } from 'electron'
 import { t } from 'i18next'
 import {
   changeCurrentProfile,
@@ -427,7 +427,7 @@ export async function createTray(): Promise<void> {
     }
     // 移除旧监听器防止累积
     ipcMain.removeAllListeners('trayIconUpdate')
-    ipcMain.on('trayIconUpdate', async (_, png: string, enabled: boolean) => {
+    ipcMain.on('trayIconUpdate', async (_, png: string, enabled: boolean, colored = false) => {
       macTrafficIconEnabled = enabled
       const appConfig = await getAppConfig()
       const status = await getTrayIconStatus()
@@ -438,7 +438,8 @@ export async function createTray(): Promise<void> {
         return
       }
       const image = nativeImage.createFromDataURL(png).resize({ height: 16 })
-      image.setTemplateImage(true)
+      // 带状态色的图不能当 template image，否则 macOS 只取 alpha 通道，颜色会被丢掉（#1143）
+      image.setTemplateImage(!colored)
       tray?.setImage(image)
       await updateTrayToolTip(undefined, undefined, false)
     })
@@ -607,6 +608,33 @@ const getIconPaths = (): Record<TrayIconStatus, string> => {
       green: pngIconGreen,
       red: pngIconRed
     }
+  }
+}
+
+// macOS 打开“在状态栏显示网速”后，托盘图标改由渲染进程把图标和文字合成一张图，主进程只负责显示。
+// 合成图此前一律按 template image 处理，macOS 只取 alpha 通道，系统代理/虚拟网卡的状态色全部丢失，
+// 也就是“显示网速时图标颜色无效”（#1143）。这里把该用哪张图、文字用什么颜色告诉渲染进程，
+// 由它连状态色一起画进去；不带状态色时保持原样，继续走 template image。
+export async function getTrayTrafficStyle(): Promise<ITrayTrafficStyle> {
+  const { disableTrayIconColor = false } = await getAppConfig()
+  const status = await getTrayIconStatus()
+  const colored = !disableTrayIconColor && status !== 'white'
+  const source = nativeImage.createFromPath(colored ? getIconPaths()[status] : templateIcon)
+  // 只缩不放：状态图标是 512px，直接丢给渲染进程既浪费又要一次性缩到 36px；模板图标本身只有 64px
+  const icon =
+    source.getSize().height > customTrayIconSize * 8
+      ? source.resize({ height: customTrayIconSize * 8, quality: 'best' })
+      : source
+  // template image 由系统按菜单栏外观自动反色，自己上色时只能跟随系统外观。
+  // 这里读系统级设置而不是 nativeTheme：后者会被应用内的浅色/深色主题覆盖，而菜单栏跟的是系统。
+  const systemDark =
+    process.platform === 'darwin' &&
+    systemPreferences.getUserDefault('AppleInterfaceStyle', 'string') === 'Dark'
+
+  return {
+    icon: icon.isEmpty() ? '' : icon.toDataURL(),
+    colored,
+    textColor: colored && systemDark ? '#ffffff' : '#000000'
   }
 }
 

--- a/src/main/sys/ssid.ts
+++ b/src/main/sys/ssid.ts
@@ -1,4 +1,5 @@
 import { exec, spawn } from 'child_process'
+import { networkInterfaces } from 'os'
 import { promisify } from 'util'
 import { ipcMain, net } from 'electron'
 import { getAppConfig, patchAppConfig, patchControledMihomoConfig } from '../config'
@@ -41,6 +42,28 @@ let ssidCheckInterval: NodeJS.Timeout | null = null
 let networkWatcher: ReturnType<typeof spawn> | null = null
 let watcherDebounce: NodeJS.Timeout | null = null
 let profileBeforeSSIDSwitch: string | undefined
+let lastNetworkFingerprint: string | undefined
+let lastSSIDProbeAt = 0
+
+// 读不到 SSID 时的兜底重试间隔
+const unknownSSIDRetryInterval = 300000
+
+// Windows 11 把 SSID 当作位置信息：每次 `netsh wlan show interfaces` 都会让
+// 「网络命令外壳」向系统申请一次定位，托盘上因此每个轮询周期闪一次定位图标。
+// 网卡地址没变时 SSID 不可能变，先用这个免费的指纹过一道，只有网络真的动过才去问 netsh。
+function networkFingerprint(): string {
+  const interfaces = networkInterfaces()
+  return Object.keys(interfaces)
+    .sort()
+    .map((name) => {
+      const addresses = (interfaces[name] ?? [])
+        .map((address) => `${address.address}/${address.mac}`)
+        .sort()
+        .join(',')
+      return `${name}=${addresses}`
+    })
+    .join(';')
+}
 
 async function handleSSIDChange(): Promise<void> {
   try {
@@ -52,6 +75,17 @@ async function handleSSIDChange(): Promise<void> {
       ssidProfileRestore = false
     } = await getAppConfig()
     if (pauseSSID.length === 0 && Object.keys(ssidProfileMap).length === 0) return
+    const fingerprint = networkFingerprint()
+    const now = Date.now()
+    // 指纹没变就跳过；上次没读到 SSID（无线还没连上、没有无线网卡）时留一条慢速兜底重试
+    if (
+      fingerprint === lastNetworkFingerprint &&
+      (lastSSID !== undefined || now - lastSSIDProbeAt < unknownSSIDRetryInterval)
+    ) {
+      return
+    }
+    lastNetworkFingerprint = fingerprint
+    lastSSIDProbeAt = now
     const currentSSID = await getCurrentSSID()
     if (currentSSID === lastSSID) return
     const previousSSID = lastSSID
@@ -184,6 +218,8 @@ export async function startSSIDCheck(): Promise<void> {
 }
 
 export function stopSSIDCheck(): void {
+  lastNetworkFingerprint = undefined
+  lastSSIDProbeAt = 0
   stopNetworkWatcher()
   if (ssidCheckInterval) {
     clearInterval(ssidCheckInterval)

--- a/src/main/utils/init.ts
+++ b/src/main/utils/init.ts
@@ -222,7 +222,13 @@ async function initFiles(): Promise<void> {
             await initLogger.warn(`Skipping ${file}: file is in use or permission denied`)
             return
           }
-          throw error
+          // ENOENT 不代表源文件不存在（入口已检查过），而是 cp() 内部先 stat 再 unlink/chmod 时
+          // 目标被别人换掉了——内核的 geo 自动更新、杀毒软件、另一个实例都会碰 work 目录。
+          // 直接抛出会让 geoip.dat 这类关键文件把整个 initFiles 拖垮，重试一次即可。
+          if (code !== 'ENOENT') throw error
+          await initLogger.warn(`Retrying ${file}: target changed while copying`)
+          await new Promise((resolve) => setTimeout(resolve, 100))
+          await cp(sourcePath, targetPath, { recursive: true, force: true })
         }
       })
     )

--- a/src/main/utils/ipc.ts
+++ b/src/main/utils/ipc.ts
@@ -104,6 +104,7 @@ import { getInterfaces } from '../sys/interface'
 import {
   closeTrayIcon,
   copyEnv,
+  getTrayTrafficStyle,
   showTrayIcon,
   updateTrayIcon,
   updateTrayIconImmediate
@@ -347,6 +348,7 @@ const asyncHandlers: Record<string, AsyncFn> = {
   showTrayIcon,
   closeTrayIcon,
   updateTrayIcon,
+  getTrayTrafficStyle,
   // Floating Window
   showFloatingWindow,
   closeFloatingWindow,

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -312,7 +312,8 @@ function setupWindowEvents(window: BrowserWindow): void {
       useDockIcon = true
     } = await getAppConfig()
 
-    if (!useDockIcon) {
+    // 读配置是异步的，这期间窗口可能已被再次显示（快速点击托盘），此时不能再隐藏 Dock 图标
+    if (!useDockIcon && !window.isDestroyed() && !window.isVisible()) {
       hideDockIcon()
     }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -130,6 +130,7 @@ const validInvokeChannels = [
   'closeTrayIcon',
   'updateTrayIcon',
   'updateTrayIconImmediate',
+  'getTrayTrafficStyle',
   // Window
   'showMainWindow',
   'closeMainWindow',

--- a/src/renderer/src/components/base/collapse-input.tsx
+++ b/src/renderer/src/components/base/collapse-input.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useCallback } from 'react'
+import React, { useEffect, useRef, useState, useCallback } from 'react'
 import { Input, InputProps } from '@heroui/react'
 import { FaSearch } from 'react-icons/fa'
 
@@ -11,13 +11,27 @@ const CollapseInput: React.FC<CollapseInputProps> = (props) => {
   const { title, value, onValueChange, ...inputProps } = props
   const inputRef = useRef<HTMLInputElement>(null)
   const isComposingRef = useRef(false)
+  const mountedOnceRef = useRef(false)
   const [localValue, setLocalValue] = useState(value || '')
+  const expanded = String(localValue ?? '').length > 0
 
   // 同步外部 value 变化
   React.useEffect(() => {
     if (!isComposingRef.current) {
       setLocalValue(value || '')
     }
+  }, [value])
+
+  // 输入框可能被宿主（如虚拟列表里的分组标题）在筛选结果变化时整块卸载重建，
+  // 焦点随之丢失、输入框缩回宽度 0。带着搜索词重新挂载且焦点无处可去时把焦点收回来，
+  // 用户才能继续输入而不是被打断（#332、#1621）。
+  useEffect(() => {
+    if (mountedOnceRef.current) return
+    mountedOnceRef.current = true
+    if (!value) return
+    const active = document.activeElement
+    if (active && active !== document.body) return
+    inputRef.current?.focus({ preventScroll: true })
   }, [value])
 
   const handleChange = useCallback(
@@ -58,7 +72,8 @@ const CollapseInput: React.FC<CollapseInputProps> = (props) => {
         style={{ paddingInlineEnd: 0 }}
         classNames={{
           inputWrapper: 'cursor-pointer bg-transparent p-0 data-[hover=true]:bg-content2',
-          input: 'w-0 focus:w-[150px] focus:ml-2 transition-all duration-200'
+          // 有搜索词时保持展开，否则筛选一生效就缩回宽度 0，用户看不到也改不了当前条件
+          input: `${expanded ? 'w-[150px] ml-2' : 'w-0'} focus:w-[150px] focus:ml-2 transition-all duration-200`
         }}
         endContent={
           <div

--- a/src/renderer/src/components/sider/conn-card.tsx
+++ b/src/renderer/src/components/sider/conn-card.tsx
@@ -7,8 +7,9 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { IoLink } from 'react-icons/io5'
 import { useAppConfig } from '@renderer/hooks/use-app-config'
+import { useControledMihomoConfig } from '@renderer/hooks/use-controled-mihomo-config'
 import { platform } from '@renderer/utils/init'
-import { updateTrayIcon } from '@renderer/utils/ipc'
+import { getTrayTrafficStyle, updateTrayIcon } from '@renderer/utils/ipc'
 import { Line } from 'react-chartjs-2'
 import {
   Chart as ChartJS,
@@ -31,12 +32,16 @@ interface Props {
 const ConnCard: React.FC<Props> = (props) => {
   const { iconOnly } = props
   const { appConfig } = useAppConfig()
+  const { controledMihomoConfig } = useControledMihomoConfig()
   const {
     showTraffic = false,
     connectionCardStatus = 'col-span-2',
     disableAnimations = false,
-    hideConnectionCardWave = false
+    hideConnectionCardWave = false,
+    disableTrayIconColor = false
   } = appConfig || {}
+  const sysProxyEnabled = appConfig?.sysProxy?.enable
+  const tunEnabled = controledMihomoConfig?.tun?.enable
   const location = useLocation()
   const navigate = useNavigate()
   const match = location.pathname.includes('/connections')
@@ -146,7 +151,7 @@ const ConnCard: React.FC<Props> = (props) => {
         currentUploadRef.current = up
         currentDownloadRef.current = down
         const png = renderTrafficIcon(up, down)
-        window.electron.ipcRenderer.send('trayIconUpdate', png, true)
+        window.electron.ipcRenderer.send('trayIconUpdate', png, true, trayIconColored)
       }
     }
   }, [])
@@ -166,17 +171,49 @@ const ConnCard: React.FC<Props> = (props) => {
       currentUploadRef.current = undefined
       currentDownloadRef.current = undefined
       const png = renderTrafficIcon(0, 0)
-      window.electron.ipcRenderer.send('trayIconUpdate', png, true)
+      window.electron.ipcRenderer.send('trayIconUpdate', png, true, trayIconColored)
       hasShowTrafficRef.current = true
     } else if (hasShowTrafficRef.current) {
       // 关闭：先让主进程退出流量图标模式（enabled=false 会清掉它的提前 return），
       // 再请主进程用 resources 里的真实图标重绘一次；只发这条 IPC 的话托盘会一直停在
       // 渲染进程发过去的这张兜底图上，状态色丢失且必须重启才恢复
-      window.electron.ipcRenderer.send('trayIconUpdate', trayIconBase64, false)
+      window.electron.ipcRenderer.send('trayIconUpdate', trayIconBase64, false, false)
       hasShowTrafficRef.current = false
       updateTrayIcon().catch(() => {})
     }
   }, [showTraffic])
+
+  // 网速图标是渲染进程把图标和文字合成一张图交给主进程显示的，主进程无法再往上叠状态色，
+  // 所以系统代理/虚拟网卡的颜色必须在这里一起画进去，否则打开网速显示后颜色就失效（#1143）。
+  useEffect(() => {
+    if (platform !== 'darwin' || !showTraffic) return
+    let cancelled = false
+    const syncTrayStyle = async (): Promise<void> => {
+      const style = await getTrayTrafficStyle()
+      let logo: HTMLImageElement | null = null
+      if (style.icon) {
+        const image = new Image()
+        image.src = style.icon
+        // 先解码再启用，避免这一帧画出一个没有图标的托盘
+        try {
+          await image.decode()
+          logo = image
+        } catch {
+          logo = null
+        }
+      }
+      if (cancelled) return
+      trayLogo = logo
+      trayTextColor = style.textColor
+      trayIconColored = style.colored
+      const png = renderTrafficIcon(currentUploadRef.current ?? 0, currentDownloadRef.current ?? 0)
+      window.electron.ipcRenderer.send('trayIconUpdate', png, true, style.colored)
+    }
+    syncTrayStyle().catch(() => {})
+    return (): void => {
+      cancelled = true
+    }
+  }, [showTraffic, sysProxyEnabled, tunEnabled, disableTrayIconColor])
 
   if (iconOnly) {
     return (
@@ -310,6 +347,12 @@ trafficIcon.onload = () => {
 }
 trafficIcon.src = trayIconBase64
 
+// 主进程下发的托盘样式（见 getTrayTrafficStyle）。拿不到时退回内置图标和黑色文字，
+// 也就是原来的 template image 行为。
+let trayLogo: HTMLImageElement | null = null
+let trayTextColor = 'black'
+let trayIconColored = false
+
 function renderTrafficIcon(upload: number, download: number): string {
   if (!trafficCanvas) {
     trafficCanvas = document.createElement('canvas')
@@ -322,11 +365,12 @@ function renderTrafficIcon(upload: number, download: number): string {
   }
   const ctx = trafficCtx
   ctx.clearRect(0, 0, ICON_W, ICON_H)
-  if (trafficIconLoaded) {
-    ctx.drawImage(trafficIcon, 0, 0, ICON_H, ICON_H)
+  const logo = trayLogo ?? (trafficIconLoaded ? trafficIcon : null)
+  if (logo) {
+    ctx.drawImage(logo, 0, 0, ICON_H, ICON_H)
   }
   ctx.font = 'bold 18px "PingFang SC"'
-  ctx.fillStyle = 'black'
+  ctx.fillStyle = trayTextColor
   ctx.textAlign = 'right'
   ctx.fillText(`${calcTraffic(upload)}/s`, ICON_W, 15)
   ctx.fillText(`${calcTraffic(download)}/s`, ICON_W, 34)

--- a/src/renderer/src/pages/proxies.tsx
+++ b/src/renderer/src/pages/proxies.tsx
@@ -505,7 +505,10 @@ const Proxies: React.FC = () => {
                   >
                     {proxyDisplayMode === 'full' && (
                       <Chip size="sm" className="my-1 mr-2">
-                        {groups[index].all.length}
+                        {/* 搜索时显示过滤后的节点数，显示总数会让人以为筛选没生效（#332） */}
+                        {searchValue[index] && isOpen[index]
+                          ? (allProxies[index]?.length ?? 0)
+                          : groups[index].all.length}
                       </Chip>
                     )}
                     <CollapseInput
@@ -517,6 +520,10 @@ const Proxies: React.FC = () => {
                           newSearchValue[index] = v
                           return newSearchValue
                         })
+                        // 过滤会改变列表总高度。不把正在筛选的分组标题钉回顶部的话，
+                        // 它会被滚出渲染窗口而卸载，搜索框随之消失、焦点丢失，
+                        // 中文输入法的组词也被打断（#332、#1621）。
+                        virtuosoRef.current?.scrollToIndex({ groupIndex: index, align: 'start' })
                       }}
                     />
                     <Button

--- a/src/renderer/src/pages/tun.tsx
+++ b/src/renderer/src/pages/tun.tsx
@@ -88,7 +88,9 @@ const Tun: React.FC = () => {
   }
 
   const onSave = async (patch: Partial<IMihomoConfig>): Promise<void> => {
-    const tunPatch = { ...patch.tun }
+    // 内核的 PATCH /configs 里 tun.enable 是非指针 bool：请求体带了 tun 却没带 enable
+    // 就会被解析成 false，ReCreateTun 随即把虚拟网卡拆掉。必须显式带上当前开关状态。
+    const tunPatch = { enable: tun?.enable ?? false, ...patch.tun }
     if (hasInvalidExcludeAddress) {
       // 存在非法条目时不覆盖已保存的排除地址，避免静默丢弃用户数据；其它 TUN 设置照常保存
       delete tunPatch['route-exclude-address']

--- a/src/renderer/src/utils/ipc.ts
+++ b/src/renderer/src/utils/ipc.ts
@@ -144,6 +144,7 @@ interface IpcApi {
   showTrayIcon: () => Promise<void>
   closeTrayIcon: () => Promise<void>
   updateTrayIcon: () => Promise<void>
+  getTrayTrafficStyle: () => Promise<ITrayTrafficStyle>
   // Window
   showMainWindow: () => Promise<void>
   closeMainWindow: () => Promise<void>
@@ -310,6 +311,7 @@ export const {
   showTrayIcon,
   closeTrayIcon,
   updateTrayIcon,
+  getTrayTrafficStyle,
   // Window
   showMainWindow,
   closeMainWindow,

--- a/src/shared/types.d.ts
+++ b/src/shared/types.d.ts
@@ -264,6 +264,16 @@ interface ICustomTrayIcons {
   tun?: string
 }
 
+// macOS 状态栏显示网速时托盘图标由渲染进程合成，这些是主进程告诉它该怎么画的参数
+interface ITrayTrafficStyle {
+  // 当前状态对应的托盘图标，data URL
+  icon: string
+  // 图标带状态色时为 true，主进程据此不再把合成图当作 template image
+  colored: boolean
+  // 文字颜色；template image 由系统自动反色，带色时必须自己跟随系统外观
+  textColor: string
+}
+
 interface IAppConfig {
   core: 'mihomo' | 'mihomo-alpha' | 'mihomo-smart' | 'mihomo-specific'
   specificVersion?: string


### PR DESCRIPTION
Nine unrelated one-file fixes, grouped to avoid opening nine pull requests.

- **#1867** The Dock icon stayed visible when the tray was clicked quickly.
  Electron's `DockHide` returns immediately if `DockShow` ran within the last
  second (it works around a macOS bug with duplicate dock icons), so the hide was
  silently dropped. The two are kept in sync now.
- **#1143** With the traffic display on, the tray icon lost its status colour. The
  icon is composited in the renderer and the main process called
  `setTemplateImage(true)` unconditionally; macOS then uses only the alpha channel.
  Verified on a real macOS 26.5.2 machine by rendering the same coloured icon as a
  template image and as a normal image and counting matching pixels in a menu bar
  screenshot: the template variant contributes none. Dark mode is decided from
  `AppleInterfaceStyle` rather than `nativeTheme`, because the menu bar follows the
  system and not the in-app theme.
- **#2046** Losing the floating window left no way back to the main window; the
  tray is restored instead.
- **#415** The floating window forgot its position when parked against a screen edge.
- **#332, #1621** The proxy group search box was unmounted while filtering, which
  also broke IME composition, so Chinese could not be typed.
- **#554** Saving the TUN settings sent a patch without `enable`. The core's
  `tunSchema.Enable` is a non-pointer bool, so a missing field means false and
  `pointerOrDefaultTun` turned the switch off — every save tore the adapter down.
- **#323** WebDAV basic auth encoded credentials as latin-1, which fails for
  non-ASCII usernames and passwords. UTF-8 now.
- **#479** Windows treats the SSID as location data, so polling it made the app
  request location roughly every 30 seconds. The SSID is only queried when the
  interface fingerprint changes; on a steady machine the `netsh` calls drop to zero.
- **#1510 (partial)** Copying `geoip.dat` could throw ENOENT and abort the whole
  `initFiles`. The ENOENT does not mean the source is missing — `fs.cp(force)`
  stats and then unlinks the target, and the core's geo auto-update, antivirus or a
  second instance can replace it in between. Reproduced 2275 times out of 2321
  attempts. It retries once now. The reported crash while updating a profile is
  not addressed.

Closes #1867 #1143 #2046 #415 #332 #1621 #554 #323 #479
Refs #1510