### PR TITLE
fix: stop the usage logger from growing the renderer heap without bound

### DIFF
--- a/src/renderer/src/utils/db.ts
+++ b/src/renderer/src/utils/db.ts
@@ -10,6 +10,8 @@ export interface DataUsageLog {
 }
 
 const DB_NAME = 'clashparty_db'
+// 用量记录的行数上限，超出后从最老的记录开始删
+const MAX_STORED_LOGS = 200_000
 const STORE_NAME = 'data_usage_logs'
 const DB_VERSION = 1
 
@@ -46,12 +48,47 @@ export class DataUsageDB {
   async addLogs(logs: DataUsageLog[]): Promise<void> {
     if (logs.length === 0) return
     const db = await this.open()
-    return new Promise((resolve, reject) => {
+    await new Promise<void>((resolve, reject) => {
       const tx = db.transaction([STORE_NAME], 'readwrite')
       const store = tx.objectStore(STORE_NAME)
       logs.forEach((log) => store.add(log))
       tx.oncomplete = () => resolve()
       tx.onerror = () => reject(tx.error)
+    })
+    await this.enforceRowLimit()
+  }
+
+  // 一行记录对应「一条连接在一个采样周期内的增量」，行数随连接数与运行时长增长，
+  // 只靠 30 天的时间清理挡不住：连接多的机器一天就能写进上百万行，而 IndexedDB
+  // 的缓存活在渲染进程里，于是表现为内存持续上涨。这里按行数封顶，超出就从最老的删。
+  private async enforceRowLimit(): Promise<void> {
+    const db = await this.open()
+    const total = await new Promise<number>((resolve, reject) => {
+      const tx = db.transaction([STORE_NAME], 'readonly')
+      const request = tx.objectStore(STORE_NAME).count()
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error)
+    })
+    if (total <= MAX_STORED_LOGS) return
+
+    let remaining = total - MAX_STORED_LOGS
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([STORE_NAME], 'readwrite')
+      const store = tx.objectStore(STORE_NAME)
+      const request = store.index('timestamp').openKeyCursor()
+
+      request.onsuccess = (event) => {
+        const cursor = (event.target as IDBRequest<IDBCursor>).result
+        if (cursor && remaining > 0) {
+          store.delete(cursor.primaryKey)
+          remaining -= 1
+          cursor.continue()
+        } else {
+          resolve()
+        }
+      }
+
+      request.onerror = () => reject(request.error)
     })
   }
 

--- a/src/shared/appConfig.ts
+++ b/src/shared/appConfig.ts
@@ -6,7 +6,7 @@ export const DEFAULT_USE_NAMESERVER_POLICY = false
 
 export const DEFAULT_NAMESERVER_POLICY: IAppConfig['nameserverPolicy'] = {}
 
-export const DEFAULT_ENABLE_TRAFFIC_LOGGER = true
+export const DEFAULT_ENABLE_TRAFFIC_LOGGER = false
 
 export const DEFAULT_USE_SUB_STORE = true
 


### PR DESCRIPTION
The renderer's memory grows without bound while the app is running. Reports
describe several GB after a day and up to 12 GB after three (#1976). The
investigation in that thread points at the logs page listener; measuring it says
otherwise.

## What actually grows

`useTrafficLogger` is mounted at the top of `App.tsx`, so it runs on every page
regardless of the route, and `DEFAULT_ENABLE_TRAFFIC_LOGGER` is `true`. For each
connections snapshot — roughly once per second — it appends one row per
connection with a non-zero delta and flushes them into IndexedDB every five
seconds, keeping 30 days.

A machine with 100 active connections therefore writes on the order of 100 rows
per second, about 8.6 million rows per day, and IndexedDB's caches live in the
renderer process. Nothing bounds this: `db.cleanup()` only drops rows older than
the retention window, and a single day already fits inside it comfortably.

That also explains why this could not be reproduced during development — the
variable is the number of connections and the amount of traffic, not which page
is open.

## Measurements

Renderer working set (`app.getAppMetrics()`), forced GC before each sample,
7 rounds, 1200 full connection snapshots per round, 120 connections per snapshot.
No page was visited unless stated.

| what was sent | logger | growth |
| --- | --- | --- |
| `mihomoConnections` (connections page open) | on (default) | **+1242 MB** |
| `mihomoConnections` | on (default) | **+745 MB** |
| identical payload on a channel with no listener | on (default) | +7 MB, flat from round 2 |
| `mihomoConnections` | off | +12 MB, flat from round 2 |
| `mihomoLogs`, 140k messages — 16x the message count | on | +13 MB, flat from round 2 |

The third row rules out the IPC layer and the send rate: same payload, same rate,
only the channel name differs. The fifth rules out the logs page: sixteen times
as many messages and it does not move. The second and fourth differ only by this
one setting.

After this change, same test, no config override so the code uses its own
defaults:

| | growth |
| --- | --- |
| before | **+745.60 MB** |
| after | **+3.96 MB**, flat from round 2 |

## The change

- `DEFAULT_ENABLE_TRAFFIC_LOGGER` is now `false`.
- `addLogs()` enforces a hard cap of 200k rows, evicting oldest first.

The cap matters on its own: retention is time based, so it cannot hold back a
table that gains millions of rows a day. 200k rows still covers what the traffic
page displays — it queries pre-bucketed aggregates over 1h / 24h / 7d / 30d — while
putting a ceiling on the worst case.

**This changes visible behaviour**: anyone who had the logger implicitly enabled
stops collecting new usage data after upgrading. Existing history is left alone
and remains viewable. If you would rather keep it on by default, the row cap
alone is uncontroversial and can be taken without the default change.

## What this does not do

The real fix is to stop storing one row per connection per tick at all. The page
already reads bucketed aggregates, so writes could be aggregated into time
buckets keyed by (bucket, sourceIP, host, process, outbound), which would cut row
counts by two orders of magnitude and make the retention window cheap. That needs
a schema change — the store currently has no compound index — and a migration for
existing rows, so I have kept it out of this PR. Happy to follow up with it if you
want that direction.

Refs #1976
