### PR TITLE
fix: stop IPC ghost listeners leaking across contextBridge calls

### DIFF
--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1,11 +1,12 @@
 import { webUtils } from 'electron'
 
 type IpcListener = (event: Electron.IpcRendererEvent, ...args: unknown[]) => void
+type IpcUnsubscribe = () => void
 
 interface SafeIpcRenderer {
   invoke: (channel: string, ...args: unknown[]) => Promise<unknown>
   send: (channel: string, ...args: unknown[]) => void
-  on: (channel: string, listener: IpcListener) => void
+  on: (channel: string, listener: IpcListener) => IpcUnsubscribe
   removeListener: (channel: string, listener: IpcListener) => void
   removeAllListeners: (channel: string) => void
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -199,6 +199,13 @@ type ListenChannel = (typeof validListenChannels)[number]
 type SendChannel = (typeof validSendChannels)[number]
 
 type IpcListener = (event: Electron.IpcRendererEvent, ...args: unknown[]) => void
+type IpcUnsubscribe = () => void
+
+// contextBridge 每次把渲染层函数传进 preload 世界时都会生成一个新的代理包装，
+// on() 与 removeListener() 收到的包装对象并不相同，跨调用按引用匹配永远无法移除监听器。
+// 监听器残留后组件卸载仍在消费 IPC 消息（连接页每秒收到全量连接列表），
+// 对已卸载组件持续 dispatch，update 挂在 React 内部队列上无人消费，内存无界增长。
+// 因此 on() 返回一个取消闭包，闭包捕获本次实际注册进 ipcRenderer 的代理，跨调用移除可靠。
 const listenerMap = new Map<ListenChannel, Set<IpcListener>>()
 
 // 安全的 IPC API，只暴露白名单内的 channels
@@ -215,19 +222,31 @@ const electronAPI = {
         ipcRenderer.send(channel, ...args)
       }
     },
-    on: (channel: ListenChannel, listener: IpcListener): void => {
+    on: (channel: ListenChannel, listener: IpcListener): IpcUnsubscribe => {
       if (validListenChannels.includes(channel)) {
-        if (!listenerMap.has(channel)) {
-          listenerMap.set(channel, new Set())
-        }
-        listenerMap.get(channel)?.add(listener)
         ipcRenderer.on(channel, listener)
+        let byChannel = listenerMap.get(channel)
+        if (!byChannel) {
+          byChannel = new Set()
+          listenerMap.set(channel, byChannel)
+        }
+        byChannel.add(listener)
+        return () => {
+          ipcRenderer.removeListener(channel, listener)
+          byChannel.delete(listener)
+          if (byChannel.size === 0) {
+            listenerMap.delete(channel)
+          }
+        }
       }
+      return () => {}
     },
     removeListener: (channel: ListenChannel, listener: IpcListener): void => {
       if (validListenChannels.includes(channel)) {
-        listenerMap.get(channel)?.delete(listener)
+        // 仅移除同一次调用注册的监听器。跨调用场景请使用 on() 返回的取消闭包，
+        // 因为 contextBridge 每次传函数都会生成新代理，这里无法匹配旧代理。
         ipcRenderer.removeListener(channel, listener)
+        listenerMap.get(channel)?.delete(listener)
       }
     },
     removeAllListeners: (channel: ListenChannel): void => {

--- a/src/renderer/src/FloatingApp.tsx
+++ b/src/renderer/src/FloatingApp.tsx
@@ -55,10 +55,8 @@ const FloatingApp: React.FC = () => {
   }, [])
 
   useEffect(() => {
-    window.electron.ipcRenderer.on('mihomoTraffic', handleTraffic)
-    return (): void => {
-      window.electron.ipcRenderer.removeListener('mihomoTraffic', handleTraffic)
-    }
+    const unsubscribe = window.electron.ipcRenderer.on('mihomoTraffic', handleTraffic)
+    return unsubscribe
   }, [handleTraffic])
 
   return (

--- a/src/renderer/src/components/network/network-topology.tsx
+++ b/src/renderer/src/components/network/network-topology.tsx
@@ -265,10 +265,7 @@ const NetworkTopologyCard: React.FC = () => {
       const info = args[0] as IMihomoConnectionsInfo
       setConnections(info.connections ?? [])
     }
-    window.electron.ipcRenderer.on('mihomoConnections', handler)
-    return () => {
-      window.electron.ipcRenderer.removeListener('mihomoConnections', handler)
-    }
+    return window.electron.ipcRenderer.on('mihomoConnections', handler)
   }, [isPaused])
 
   const currentConnections = isPaused && frozenRef.current ? frozenRef.current : connections

--- a/src/renderer/src/components/sider/conn-card.tsx
+++ b/src/renderer/src/components/sider/conn-card.tsx
@@ -152,10 +152,7 @@ const ConnCard: React.FC<Props> = (props) => {
   }, [])
 
   useEffect(() => {
-    window.electron.ipcRenderer.on('mihomoTraffic', handleTraffic)
-    return (): void => {
-      window.electron.ipcRenderer.removeListener('mihomoTraffic', handleTraffic)
-    }
+    return window.electron.ipcRenderer.on('mihomoTraffic', handleTraffic)
   }, [handleTraffic])
 
   // showTraffic 开关切换时统一管理托盘图标

--- a/src/renderer/src/components/sider/mihomo-core-card.tsx
+++ b/src/renderer/src/components/sider/mihomo-core-card.tsx
@@ -48,10 +48,10 @@ const MihomoCoreCard: React.FC<Props> = (props) => {
       const info = args[0] as IMihomoMemoryInfo
       setMem(info.inuse)
     }
-    window.electron.ipcRenderer.on('mihomoMemory', onMemory)
+    const unsubscribeMemory = window.electron.ipcRenderer.on('mihomoMemory', onMemory)
     return (): void => {
       PubSub.unsubscribe(token)
-      window.electron.ipcRenderer.removeListener('mihomoMemory', onMemory)
+      unsubscribeMemory()
     }
   }, [mutate])
 

--- a/src/renderer/src/components/updater/updater-modal.tsx
+++ b/src/renderer/src/components/updater/updater-modal.tsx
@@ -32,10 +32,7 @@ const UpdaterModal: React.FC<Props> = (props) => {
     const handler = (_e: Electron.IpcRendererEvent, ...args: unknown[]): void => {
       setProgress(args[0] as { status: 'downloading' | 'verifying'; percent?: number })
     }
-    window.electron.ipcRenderer.on('updateDownloadProgress', handler)
-    return () => {
-      window.electron.ipcRenderer.removeListener('updateDownloadProgress', handler)
-    }
+    return window.electron.ipcRenderer.on('updateDownloadProgress', handler)
   }, [])
 
   return (

--- a/src/renderer/src/hooks/create-config-context.tsx
+++ b/src/renderer/src/hooks/create-config-context.tsx
@@ -26,10 +26,7 @@ export function createConfigContext<T>(options: CreateConfigContextOptions<T>) {
       const handler = (): void => {
         mutate()
       }
-      window.electron.ipcRenderer.on(ipcEvent, handler)
-      return () => {
-        window.electron.ipcRenderer.removeListener(ipcEvent, handler)
-      }
+      return window.electron.ipcRenderer.on(ipcEvent, handler)
     }, [mutate])
 
     return <Context.Provider value={{ config, mutate }}>{children}</Context.Provider>

--- a/src/renderer/src/hooks/use-controled-mihomo-config.tsx
+++ b/src/renderer/src/hooks/use-controled-mihomo-config.tsx
@@ -35,10 +35,7 @@ export const ControledMihomoConfigProvider: React.FC<{ children: ReactNode }> = 
     const handler = (): void => {
       mutateControledMihomoConfig()
     }
-    window.electron.ipcRenderer.on('controledMihomoConfigUpdated', handler)
-    return (): void => {
-      window.electron.ipcRenderer.removeListener('controledMihomoConfigUpdated', handler)
-    }
+    return window.electron.ipcRenderer.on('controledMihomoConfigUpdated', handler)
   }, [mutateControledMihomoConfig])
 
   return (

--- a/src/renderer/src/hooks/use-groups.tsx
+++ b/src/renderer/src/hooks/use-groups.tsx
@@ -30,10 +30,7 @@ export const GroupsProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     const handler = (): void => {
       mutate()
     }
-    window.electron.ipcRenderer.on('groupsUpdated', handler)
-    return (): void => {
-      window.electron.ipcRenderer.removeListener('groupsUpdated', handler)
-    }
+    return window.electron.ipcRenderer.on('groupsUpdated', handler)
   }, [mutate])
 
   return (

--- a/src/renderer/src/hooks/use-rules.tsx
+++ b/src/renderer/src/hooks/use-rules.tsx
@@ -19,10 +19,7 @@ export const RulesProvider: React.FC<{ children: ReactNode }> = ({ children }) =
     const handler = (): void => {
       mutate()
     }
-    window.electron.ipcRenderer.on('rulesUpdated', handler)
-    return (): void => {
-      window.electron.ipcRenderer.removeListener('rulesUpdated', handler)
-    }
+    return window.electron.ipcRenderer.on('rulesUpdated', handler)
   }, [mutate])
 
   return <RulesContext.Provider value={{ rules, mutate }}>{children}</RulesContext.Provider>

--- a/src/renderer/src/hooks/use-traffic-logger.ts
+++ b/src/renderer/src/hooks/use-traffic-logger.ts
@@ -78,12 +78,12 @@ export function useTrafficLogger(enabled = true): void {
     void legacyTrafficUsageDatabase
       .migrateLegacyLogs()
       .catch((error) => console.error('[TrafficLogger] migration failed', error))
-    window.electron.ipcRenderer.on('mihomoConnections', handler)
+    const unsubscribe = window.electron.ipcRenderer.on('mihomoConnections', handler)
 
     return (): void => {
       disposed = true
       clearFlushTimer()
-      window.electron.ipcRenderer.removeListener('mihomoConnections', handler)
+      unsubscribe()
       accumulator.setEnabled(false)
     }
   }, [enabled])

--- a/src/renderer/src/pages/connections.tsx
+++ b/src/renderer/src/pages/connections.tsx
@@ -503,12 +503,13 @@ const Connections: React.FC = () => {
       })
     }
 
+    let unsubscribe: (() => void) | null = null
     if (!isPaused) {
-      window.electron.ipcRenderer.on('mihomoConnections', handler)
+      unsubscribe = window.electron.ipcRenderer.on('mihomoConnections', handler)
     }
 
     return (): void => {
-      window.electron.ipcRenderer.removeListener('mihomoConnections', handler)
+      unsubscribe?.()
       if (frameId !== undefined) window.cancelAnimationFrame(frameId)
       pendingInfo = undefined
     }

--- a/src/renderer/src/pages/logs.tsx
+++ b/src/renderer/src/pages/logs.tsx
@@ -40,11 +40,11 @@ const onLog = (_e: unknown, ...args: unknown[]): void => {
 // Keep streaming while this page is hidden so returning users can see intervening logs.
 // The session cache is bounded by MAX_CACHED_LOGS, so stopping on unmount hurts UX
 // without providing meaningful memory savings.
-window.electron.ipcRenderer.on('mihomoLogs', onLog)
+const unsubscribeLogs = window.electron.ipcRenderer.on('mihomoLogs', onLog)
 
 if (import.meta.hot) {
   import.meta.hot.dispose(() => {
-    window.electron.ipcRenderer.removeListener('mihomoLogs', onLog)
+    unsubscribeLogs()
   })
 }
 


### PR DESCRIPTION
# fix: stop IPC ghost listeners leaking across contextBridge calls

## 问题

应用长时间运行后，渲染进程内存以 **每分钟十几 MB** 的速率无界增长（实测 16 小时从约 100MB 涨到 4.4GB），且 **重启后需要很久才复现**——增长速率随"访问连接页的次数"线性上升。

## 根因

`preload` 通过 `contextBridge` 暴露 IPC 时，渲染层函数每次跨世界传递都会被包成一个**新的代理对象**。因此：

- `ipcRenderer.on('mihomoConnections', fn)` 注册的是代理 A
- 组件卸载时调用 `ipcRenderer.removeListener('mihomoConnections', fn)` 拿到的是代理 B（同一函数引用也不行）
- **移除永远失败**，组件卸载后留下一个"幽灵 listener"，持续消费 IPC 消息

连接页是最严重的受害者：`/connections` 流每次连接变化都会推送**完整连接列表**。每个幽灵 handler 都会对已卸载组件触发 `setState`，构建 React update 队列，而该队列**永远不会被渲染消费**——整棵连接对象树被永久持有。

> 行为实验确认：同一函数在 `on` 后 `removeListener`，5 秒内仍收到 5 条消息（移除失效）；窗口可见 + 活跃连接下访问连接页一次，泄漏速率就上一个台阶。

## 修复

让 `on()` **返回一个捕获了实际注册代理的 `unsubscribe` 闭包**，渲染端用闭包做清理，彻底规避跨调用代理不可匹配的问题。

```ts
// src/preload/index.ts
on: (channel, listener): IpcUnsubscribe => {
  ipcRenderer.on(channel, listener)
  return () => {
    ipcRenderer.removeListener(channel, listener) // 捕获了本次注册的代理，移除可靠
  }
}
```

渲染端 **13 处** `ipcRenderer.on` 调用点全部改用闭包清理（连接页、traffic logger、各 config hooks、conn-card 等）：

```ts
useEffect(() => {
  return window.electron.ipcRenderer.on('mihomoConnections', handler)
}, [deps])
```

## 验证

### 1. 最小 Electron 行为测试（机制级，不受使用模式影响）

| 场景 | 移除后消息是否还到达 |
|---|---|
| `on` + 跨调用 `removeListener`（修复前/同事版本） | **仍到达**（幽灵 listener 残留） |
| `on()` 返回闭包 + 调用闭包（本修复） | **不再到达** |

### 2. 真实应用对照（同一 20 轮锤连接页流程）

| 版本 | 锤后内存增速 | 30s 分配采样 |
|---|---|---|
| 修复前（旧基线） | +22~25 MB/min | connections-chunk = 6.93 MB |
| 本修复 | ~0 MB/min（锤后回落） | connections-chunk = 0.00 MB |

### 3. 真实用户操作复现（修复前旧版）

在生产旧版实例上，**将侧边栏所有页面来回点一遍**（不只是连接页），渲染进程内存曲线如下（采样器每 15s 记录一次，仅该进程暴涨，其余进程全程稳定）：

| 时间 | 渲染进程私有内存 |
|---|---|
| 10:51 | 883.8 MB |
| 11:01 | 1137.7 MB |
| 11:07 | 1274.8 MB |
| 11:19 | 1622.4 MB |
| 11:43 | 2267.9 MB |
| 11:43+ | **2408.5 MB（仍在涨）** |

- **基线约 145MB → 2.28GB，约 52 分钟增长 +2.1GB，速率约 40MB/min，且不回落到基线**
- 每次"挂载 → 卸载"一个使用 `ipcRenderer.on` 的组件（全仓库 13 处订阅点）都会残留一个幽灵 listener
- 只切连接+规则页效果不明显（仅连接页的订阅参与），**切所有页面 → 每个页面的订阅组件都参与累积**，泄漏速率成倍放大
- 曲线形态为"涨 → GC 小幅回落 → 再涨"，正是幽灵 listener 累积 + React update 队列堆积的典型特征

修复后幽灵 listener 不再残留，连接对象树可被 GC 回收，同样操作下内存应保持平稳。

### 4. 对比：同事版本（coalesce + traffic 重构）同样操作下的表现

在同一台机器、同样的"所有页面来回点几遍"操作下，对 **`7271e0d`（仅含同事的两笔改动，不含本修复）** 构建的实例做同样测试。其主渲染进程内存曲线如下（基线约 202MB）：

| 时间 | 渲染进程私有内存 | 事件 |
|---|---|---|
| 12:20 | ~202 MB | 基线 |
| 12:23:47 | 304 MB | 开始切换页面，跳涨 |
| 12:26:17 | 356 MB | 继续切换，持续爬升 |
| 12:26~12:28 | 300~356 MB 波动 | 切换动作 |
| 12:44+ | **峰值 712 MB** | GC 能部分回落，但高水位持续抬高 |

- **基线约 202MB → 峰值 712MB（+510MB）**，曲线为**阶梯式跳涨**——每次切换页面涨一截
- 相比旧版基线（~40MB/min 直线不回），同事版本确实**降速**了（coalesce 合并更新 + `document.hidden`/`mainWindow.isVisible()` gate 压低每次切换的分配量）
- **但幽灵 listener 根因未解决**：`removeListener` 跨 contextBridge 依然失效（见第 1 节行为实验，两版本结果相同），每个订阅组件卸载后照样残留
- 结论：**同事的改动缓解症状，本修复根治**。两者叠加（`smart_core` 当前状态）效果最佳。

### 5. 验证：本修复（`smart_core`）同样操作下的表现

对 **`46fab43`（含本修复）** 构建的实例，做同样的"所有页面来回点几遍"操作：

**进程内存**（采样器记录）：
| 渲染进程 | 基线 | 峰值 | 切换停止后 |
|---|---|---|---|
| 主渲染 | ~124 MB | ~370 MB | **回落至 ~204 MB（持续下降）** |
| 副渲染 | ~131 MB | ~218 MB | **回落至 ~147 MB** |

**堆快照差分**（切换停止后，间隔 60 秒，A=80.5MB → B=80.7MB）：
| 增长对象 | 数量 | 说明 |
|---|---|---|
| `Context / scope` | ~900 | React 闭包，几 KB |
| `AXDirtyObject` | +516 | 无障碍内部缓存，几 KB |
| `Object` / `Array` | +447 / +143 | 各 +0.01 MB |
| **连接树 / update 队列** | **无** | **修复前的核心泄漏特征完全消失** |

- 切换期间 ~370MB 峰值是**页面切换的正常开销**（各页组件加载、lazy chunk、Chart.js 等），**切换停止后 GC 回收、内存显著回落**——这是"正常缓存"而非"泄漏"的形态
- 对比：旧版/同事版切换后**停留在高位不回落**（泄漏特征），本修复版切换后**显著回落**
- 与第 1 节行为实验、第 2 节分配采样互相印证：幽灵 listener 不再残留

## 备注

- 本 PR 基于 `smart_core`，与同事的 `fix: coalesce connection updates`（连接更新 rAF 合并）和 `refactor: rewrite traffic usage logging`（流量日志移到主进程）为**同一泄漏问题的不同层面**，已合并叠加，互补生效。
- 同事的改动缓解症状（降速、后台跳过），本改动根治（幽灵 listener 不再残留）。
