### PR TITLE
fix: respect server-sent update interval on first import

### DIFF
--- a/src/main/config/profile.test.ts
+++ b/src/main/config/profile.test.ts
@@ -127,3 +127,56 @@ describe('remote profile candidate validation', () => {
     expect(mocks.hotReload).toHaveBeenCalledOnce()
   })
 })
+
+describe('profile-update-interval header', () => {
+  const withInterval = (hours: string): void => {
+    mocks.axiosGet.mockResolvedValue({
+      status: 200,
+      data: newProfile,
+      headers: { 'content-type': 'text/yaml', 'profile-update-interval': hours }
+    })
+  }
+
+  it('enables auto update on first import when the server sends an interval', async () => {
+    withInterval('24')
+
+    const item = await createProfile({
+      type: 'remote',
+      name: 'Remote',
+      url: 'https://example.test'
+    })
+
+    expect(item.interval).toBe(24 * 60)
+    expect(item.autoUpdate).toBe(true)
+  })
+
+  it('keeps auto update disabled when the user turned it off', async () => {
+    withInterval('24')
+
+    const item = await createProfile({
+      id: 'remote',
+      type: 'remote',
+      name: 'Remote',
+      url: 'https://example.test',
+      autoUpdate: false
+    })
+
+    expect(item.interval).toBe(24 * 60)
+    expect(item.autoUpdate).toBe(false)
+  })
+
+  it('leaves auto update untouched when allowFixedInterval is set', async () => {
+    withInterval('24')
+
+    const item = await createProfile({
+      type: 'remote',
+      name: 'Remote',
+      url: 'https://example.test',
+      interval: 60,
+      allowFixedInterval: true
+    })
+
+    expect(item.interval).toBe(60)
+    expect(item.autoUpdate).toBe(false)
+  })
+})

--- a/src/main/config/profile.ts
+++ b/src/main/config/profile.ts
@@ -522,6 +522,12 @@ export async function createProfile(item: Partial<IProfileItem>): Promise<IProfi
       const hours = Number(headers['profile-update-interval'])
       if (Number.isFinite(hours) && hours > 0) {
         newItem.interval = Math.min(Math.ceil(hours * 60), MAX_PROFILE_INTERVAL_MINUTES)
+        // 首次导入时，服务端下发了更新周期即视为要求自动更新，与 v1.9.0 之前的行为一致。
+        // 仅在新建时生效：item.id 只有首次导入才缺省，后续定时刷新传入的是带 id 的完整条目，
+        // 因此用户之后在编辑弹窗里关闭自动更新的选择不会被覆盖。
+        if (!item.id) {
+          newItem.autoUpdate = true
+        }
       }
     }
     if (headers['subscription-userinfo']) {


### PR DESCRIPTION
## 问题

订阅响应头 `profile-update-interval` 目前只写入 `interval`，不动 `autoUpdate`。
而自 #1389 起 `createProfile` 里 `autoUpdate` 默认为 `false`：

```ts
autoUpdate: item.autoUpdate ?? false
```

调度侧两处都要求这个标志为真：

```ts
// core/profileUpdater.ts  scheduleProfileUpdate
if ((item.type !== 'remote' && item.type !== 'plugin') || !item.autoUpdate || !item.interval)
  return

// core/profileUpdater.ts  initProfileUpdater
if (item.type === 'remote' && item.autoUpdate && item.interval) {
  await addProfileUpdater(item)
  if (autoUpdateProfileOnStart) { await addProfileItem(item) }
}
```

结果是：**服务端下发了更新周期，但订阅既不定时刷新、启动时也不刷新**，用户必须自己在编辑弹窗里找到那个开关。
这与 v1.9.0 之前的行为、以及 Clash Meta 等客户端的行为都不一致 —— 它们把「收到 `profile-update-interval`」直接当作「启用自动更新」。

#1586 反馈的正是这一点。

## 改动

只在**首次导入**时打开 `autoUpdate`：

```ts
if (Number.isFinite(hours) && hours > 0) {
  newItem.interval = Math.min(Math.ceil(hours * 60), MAX_PROFILE_INTERVAL_MINUTES)
  if (!item.id) {
    newItem.autoUpdate = true
  }
}
```

`item.id` 只有首次导入时缺省 —— 定时刷新走的是 `profileUpdater.updateProfile` → `addProfileItem(item)`，
传回的是带 `id` 的完整条目。因此：

- **用户之后手动关闭自动更新的选择不会被覆盖**（#1389 引入这个开关的意图得以保留）
- `allowFixedInterval` 仍然在最外层短路，行为不变
- 本地配置、插件订阅路径都不受影响

## 测试

`src/main/config/profile.test.ts` 新增 3 个用例：

| 用例 | 断言 |
|---|---|
| 首次导入且服务端下发周期 | `interval = 1440`、`autoUpdate = true` |
| 已存在条目、用户已关闭 | `interval` 更新，但 `autoUpdate` 保持 `false` |
| `allowFixedInterval = true` | 保留本地 `interval`，不改 `autoUpdate` |

第一个用例在撤掉本次改动后会失败（`expected false to be true`），后两个是防回归护栏。

```
Test Files  1 passed (1)
     Tests  5 passed (5)
```

`pnpm lint:check` 与 `pnpm typecheck:node` 均通过，改动的两个文件无新增告警。

Closes #1586
