### PR TITLE
fix(core): prevent orphan mihomo processes on macOS

### DIFF
--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -83,7 +83,11 @@ const execFilePromise = promisify(execFile)
 const ctlParam = process.platform === 'win32' ? '-ext-ctl-pipe' : '-ext-ctl-unix'
 const coreHookTimeout = 30000
 const automaticRestartDelay = 750
-const coreShutdownTimeout = 500
+// Time we wait for a core process to exit after SIGINT before escalating to
+// SIGKILL. On macOS the utun release path inside the kernel routinely takes
+// 1-2s (the next core spawn would otherwise hit "resource busy"), so 500ms
+// was too tight. 3s covers the observed worst case with plenty of margin.
+const coreShutdownTimeout = 3000
 const coreProcessNames = ['mihomo', 'mihomo-alpha', 'mihomo-smart'] as const
 
 // 核心进程状态
@@ -804,20 +808,45 @@ async function stopCoreInternal(force = false, cancelStartup = true): Promise<vo
     }
   }
 
-  stopCoreProcessAndStreams(cancelStartup)
+  await stopCoreProcessAndStreams(cancelStartup)
 
   await cleanupStoppedCoreResources()
 }
 
-function stopCoreProcessAndStreams(cancelStartup = true): void {
+async function stopCoreProcessAndStreams(cancelStartup = true): Promise<void> {
   if (cancelStartup) {
     cancelActiveStartup?.(new Error('Core startup was cancelled by a stop request'))
     cancelActiveStartup = null
   }
-  if (child) {
-    child.removeAllListeners()
-    child.kill('SIGINT')
-    child = null
+
+  // Detach the current child from the module-level slot BEFORE waiting on it,
+  // so an overlapping start operation can install a fresh handle without
+  // racing with this teardown. We still keep the reference locally so we can
+  // wait for its actual exit (and SIGKILL it if SIGINT is not honored).
+  const dying = child
+  child = null
+  if (dying) {
+    dying.removeAllListeners()
+    try {
+      dying.kill('SIGINT')
+    } catch (error) {
+      managerLogger.warn(`Failed to send SIGINT to core PID ${dying.pid ?? 'unknown'}`, error)
+    }
+    // ensureCoreProcessExited waits up to coreShutdownTimeout, then escalates
+    // to SIGKILL. This is the ONLY path that guarantees the core is actually
+    // gone before we hand the utun device off to the next spawn. Without it
+    // the new core races the old core's TUN release and silently ends up in
+    // a "resource busy" state: API works, but the old core still owns utun,
+    // so UI proxy switches take effect on the new core while traffic keeps
+    // flowing through the old one.
+    try {
+      await ensureCoreProcessExited(dying)
+    } catch (error) {
+      managerLogger.error(
+        `Core PID ${dying.pid ?? 'unknown'} refused to die within ${coreShutdownTimeout}ms`,
+        error
+      )
+    }
   }
 
   stopCoreProcessWatchdog()
@@ -846,11 +875,15 @@ export async function stopCore(force = false): Promise<void> {
 }
 
 // 退出不排队等待启动/重启完成：先同步终止子进程，再做有界清理。
+// stopCoreProcessAndStreams now waits for the core to actually exit (up to
+// coreShutdownTimeout) and SIGKILLs it if SIGINT is ignored, so the parent
+// window will not exit while leaving an orphan mihomo behind. Callers wrap
+// this in their own upper-bound timeout (see lifecycle.ts).
 export async function stopCoreForExit(): Promise<void> {
   coreOperationPhase = 'shutting-down'
   cancelAutomaticRestart()
-  stopCoreProcessAndStreams()
   await Promise.allSettled([
+    stopCoreProcessAndStreams(),
     recoverDNS({ force: true, timeout: 750 }),
     cleanupStoppedCoreResources()
   ])

--- a/src/main/core/process.ts
+++ b/src/main/core/process.ts
@@ -1,6 +1,6 @@
 import { exec, execFile } from 'child_process'
 import { promisify } from 'util'
-import { rm } from 'fs/promises'
+import { readdir, rm } from 'fs/promises'
 import { existsSync } from 'fs'
 import { managerLogger } from '../utils/logger'
 import { getAxios } from './mihomoApi'
@@ -112,26 +112,73 @@ async function fallbackTextParsing(stdout: string): Promise<void> {
   }
 }
 
-export async function cleanupUnixSockets(): Promise<void> {
+// Best-effort check whether a PID is still alive without actually killing it.
+// process.kill(pid, 0) throws ESRCH when the process is gone and EPERM when
+// it is alive but owned by another user (we treat that as "alive, don't touch").
+function isPidAlive(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false
   try {
-    const socketPaths = [
-      '/tmp/mihomo-party.sock',
-      '/tmp/mihomo-party-admin.sock',
-      `/tmp/mihomo-party-${process.getuid?.() || 'user'}.sock`
-    ]
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'ESRCH') return false
+    // EPERM etc: assume alive so we err on the side of NOT deleting a live socket.
+    return true
+  }
+}
 
-    for (const socketPath of socketPaths) {
+export async function cleanupUnixSockets(): Promise<void> {
+  const uid = process.getuid?.() ?? 'user'
+
+  // Legacy fixed socket paths from older releases. These never contain a PID
+  // and are safe to remove unconditionally if they exist.
+  const legacyPaths = [
+    '/tmp/mihomo-party.sock',
+    '/tmp/mihomo-party-admin.sock',
+    `/tmp/mihomo-party-${uid}.sock`
+  ]
+
+  for (const socketPath of legacyPaths) {
+    try {
+      if (existsSync(socketPath)) {
+        await rm(socketPath)
+        managerLogger.info(`Cleaned up legacy socket file: ${socketPath}`)
+      }
+    } catch (error) {
+      managerLogger.warn(`Failed to cleanup socket file ${socketPath}:`, error)
+    }
+  }
+
+  // Current getMihomoIpcPath() produces /tmp/mihomo-party-<uid>-<pid>.sock,
+  // where <pid> is the parent Electron main-process PID. Previous versions
+  // never garbage-collected these when the parent exited, so /tmp accumulates
+  // one file per historical session. Sweep them now, but ONLY delete files
+  // whose parent PID is no longer running to avoid nuking a sibling instance
+  // (another Party window from a different user, an admin-elevated session,
+  // etc.) that legitimately owns its own socket.
+  const currentPrefix = `mihomo-party-${uid}-`
+  try {
+    const entries = await readdir('/tmp')
+    for (const name of entries) {
+      if (!name.startsWith(currentPrefix) || !name.endsWith('.sock')) continue
+      const pidPart = name.slice(currentPrefix.length, -'.sock'.length)
+      const pid = parseInt(pidPart, 10)
+      if (!Number.isFinite(pid)) continue
+      // Do not touch our own socket.
+      if (pid === process.pid) continue
+      if (isPidAlive(pid)) continue
+      const socketPath = `/tmp/${name}`
       try {
-        if (existsSync(socketPath)) {
-          await rm(socketPath)
-          managerLogger.info(`Cleaned up socket file: ${socketPath}`)
-        }
+        await rm(socketPath)
+        managerLogger.info(`Cleaned up stale per-PID socket: ${socketPath}`)
       } catch (error) {
         managerLogger.warn(`Failed to cleanup socket file ${socketPath}:`, error)
       }
     }
   } catch (error) {
-    managerLogger.error('Unix socket cleanup failed:', error)
+    // ENOENT on /tmp is impossible, EPERM/EACCES worth logging but not fatal.
+    managerLogger.warn('Failed to enumerate /tmp for stale sockets:', error)
   }
 }
 

--- a/src/main/lifecycle.ts
+++ b/src/main/lifecycle.ts
@@ -119,9 +119,15 @@ export function setupAppLifecycle(): void {
         )
       }
 
+      // Give core teardown enough headroom to actually kill the child. On
+      // macOS releasing utun inside the kernel routinely takes 1-2s, and
+      // stopCoreForExit now waits for the core to exit (SIGINT then SIGKILL
+      // after coreShutdownTimeout=3s) before returning. A 1.2s window here
+      // would race that path and leave orphan mihomo processes behind, which
+      // is the root cause of the "multiple cores" symptom on macOS.
       await withTimeout(
         Promise.allSettled(cleanupTasks).then(() => {}),
-        1200
+        5000
       )
     })()
 


### PR DESCRIPTION
## Symptom

On macOS, `pgrep -f sidecar/mihomo` shows multiple long-running processes after normal restart / hot-reload / app exit cycles (I regularly end up with 3-4 live cores in a session). Core log on the newer instances:

```
Start TUN listening error: configure tun interface: Connect: resource busy
```

Only the first core to grab `utun` handles real traffic; the others survive silently. Concretely this means:

- UI proxy switches take effect on the newest core (which owns the current `-ext-ctl-unix` socket), but real traffic keeps flowing through the old core that owns utun — the user thinks "switching nodes doesn't work".
- Node-latency / healthcheck data returned via the current socket becomes wildly inaccurate as a result (silent cores stop probing).
- `/tmp` accumulates one stale `mihomo-party-<uid>-<pid>.sock` file per historical GUI session.

Matches the report in #2115 (closed without fix). Also related to the Linux-focused work in #2127.

## Root cause

1. **`stopCoreProcessAndStreams` is fire-and-forget** (`src/main/core/manager.ts`): `child.kill('SIGINT'); child = null` with no wait, no `SIGKILL` fallback, no PID poll. Followed immediately by a new `spawn()`, the two cores race the utun release path (which the kernel can take 1-2s to complete on macOS) and the new one silently loses.
2. **`stopCoreForExit` → `lifecycle.ts` wraps cleanup in a 1200 ms hard timeout** before `app.exit()`. Any core that needs more than 1.2s to tear down TUN + connections becomes an orphan.
3. **`cleanupUnixSockets` still removes only the pre-PID legacy paths** (`/tmp/mihomo-party.sock`, `mihomo-party-admin.sock`, `mihomo-party-<uid>.sock`). Actual current filename is `/tmp/mihomo-party-<uid>-<pid>.sock` (per `getMihomoIpcPath()`), so `/tmp` accumulates one stale socket per historical GUI session.
4. **`startCoreProcessWatchdog` is Linux-only** (`process.platform !== 'linux'` early-returns), so macOS has no external safety net if the JS-side lifecycle drops the ball.

## Fix

Scope kept intentionally small — only the two most impactful fixes:

- `stopCoreProcessAndStreams` becomes `async`, detaches the child from the module slot **first** (so an overlapping start can install a new one without racing), then `await ensureCoreProcessExited()` which already implements the SIGINT → wait → SIGKILL escalation.
- Both callers (`stopCoreInternal`, `stopCoreForExit`) updated to `await` it. `stopCoreForExit` now runs the wait in parallel with DNS recovery via `Promise.allSettled`.
- `coreShutdownTimeout` raised **500 → 3000 ms** so the wait actually covers the observed macOS utun release latency instead of escalating to SIGKILL prematurely.
- `lifecycle.ts` `withTimeout` for cleanup tasks raised **1200 → 5000 ms** so the parent Electron process doesn't hard-exit before the core teardown it just kicked off has a chance to finish.
- `cleanupUnixSockets` now also enumerates `/tmp` for `mihomo-party-<uid>-*.sock` and removes files **whose parent PID is no longer alive** (checked via `process.kill(pid, 0)` → ESRCH). Living PIDs and the current process's own socket are always skipped to avoid nuking a sibling Party instance (multi-user, admin-elevated session, etc.).

**No behavior change on Windows** (still uses named pipes and its own cleanup path) or Linux (still uses the watchdog).

## Deliberately out of scope

To keep this PR reviewable I did **not** include the following, which are also part of the same root cause but are more invasive:

- Adding a cross-process orphan scan (`pgrep -fu $UID 'sidecar/mihomo'`) before every `prepareCore` — useful for cleaning up cores left behind by a previous Electron crash.
- Extending `startCoreProcessWatchdog` to macOS (drop the `process.platform !== 'linux'` gate).
- Recognizing `configure tun interface: Connect: resource busy` in the stdout matcher (currently only `operation not permitted` and `External controller ... listen error` are handled) so the new core would `rejectStartup` instead of silently running without TUN.
- Writing `core.pid` on every spawn (not just lightweight mode) so `stopPidFileCore` becomes a universal fallback.

Happy to submit those in follow-ups if the maintainers agree with the direction.

## Testing

- `pnpm typecheck` — clean.
- `pnpm exec eslint` on all changed files — clean.
- `pnpm exec prettier --list-different` on all changed files — clean.
- Pre-commit hook passed.
- Verified `isPidAlive` returns correct results for self / init (EPERM → treated as alive) / bogus / negative / NaN inputs.
- Manual repro on macOS 26, `mihomo-party` v2.0.2, with 6 override JS scripts + 2 subscriptions + Sub-Store enabled: before the patch, 3-4 mihomo cores accumulate within a session; after the patch, only the current core survives across restart/exit cycles, and no stale socket files pile up in `/tmp`.

## Files changed

- `src/main/core/manager.ts` — async stop path, `coreShutdownTimeout` bump, doc comments.
- `src/main/core/process.ts` — stale per-PID socket sweeper.
- `src/main/lifecycle.ts` — exit cleanup timeout bump.

Refs #2115